### PR TITLE
fix logic error in interrupt_wait_and_kill

### DIFF
--- a/src/shrinkray/__main__.py
+++ b/src/shrinkray/__main__.py
@@ -73,7 +73,7 @@ async def interrupt_wait_and_kill(sp: "trio.Process", delay: float = 0.1) -> Non
         with trio.move_on_after(delay):
             await sp.wait()
 
-        if sp.returncode is not None:
+        if sp.returncode is None:
             raise ValueError(
                 f"Could not kill subprocess with pid {sp.pid}. Something has gone seriously wrong."
             )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import trio
+import subprocess
+
+from shrinkray.__main__ import interrupt_wait_and_kill
+
+
+
+async def test_kill_process():
+    async with trio.open_nursery() as nursery:
+        kwargs = dict(
+            universal_newlines=False,
+            preexec_fn=os.setsid,
+            check=False,
+            stdout=subprocess.PIPE,
+        )
+        def call_with_kwargs(task_status=trio.TASK_STATUS_IGNORED):  # type: ignore
+            # start a subprocess that will just ignore SIGINT signals
+            return trio.run_process(
+                    [sys.executable,
+                     "-c",
+                     "import signal, sys, time; signal.signal(signal.SIGINT, lambda *a: 1); print(1); sys.stdout.flush(); time.sleep(1000)"],
+                    **kwargs, task_status=task_status)
+
+        sp = await nursery.start(call_with_kwargs)
+        line = await sp.stdout.receive_some(2)
+        assert line == b"1\n"
+        # must not raise ValueError but succeed at killing the process
+        await interrupt_wait_and_kill(sp)
+        assert sp.returncode is not None
+        assert sp.returncode != 0


### PR DESCRIPTION
fixes #6.

While writing the test I first missed the `preexec_fn=os.setsid`, and because `interrupt_wait_and_kill` uses `signal_group`, the test process got a `SIGINT` as well, stopping the test. This made me wonder about the `assert` in `signal_group`:

```python
def signal_group(sp: "trio.Process", signal: int) -> None:
    gid = os.getpgid(sp.pid)
    assert gid != os.getgid()
    os.killpg(gid, signal)
```

`os.getgid` gives you the group id of the user running the process, not the process group id of the current procces, no? So maybe `assert gid != os.getpgid(0)` was what was meant? I'm happy to fix that too.