### PR TITLE
Don't try to display unprintable bytes

### DIFF
--- a/src/shrinkray/__main__.py
+++ b/src/shrinkray/__main__.py
@@ -870,7 +870,11 @@ class ShrinkRayUISingleFile(UrwidUI[bytes]):
                 continue
             current = await self.state.attempt_format(self.problem.current_test_case)
             if current.count(b"\n") <= 50:
-                self.diff_to_display.set_text(current)
+                try:
+                    current.decode("utf-8")
+                    self.diff_to_display.set_text(current)
+                except UnicodeError:
+                    pass
                 await trio.sleep(0.1)
                 continue
 


### PR DESCRIPTION
In the case of binary input, the bytes in current may not be UTF-8 or otherwise printable.  In this case, we should not try to print them.

This PR closes #9.