### PR TITLE
Fix import.

### DIFF
--- a/src/shrinkray/__main__.py
+++ b/src/shrinkray/__main__.py
@@ -22,7 +22,7 @@ import click
 import humanize
 import trio
 import urwid
-import urwid.raw_display
+from urwid import raw_display
 from attrs import define
 from binaryornot.check import is_binary_string
 


### PR DESCRIPTION
Without this change I get (filenames elided for clarity):

```
Traceback (most recent call last):
  File "../.local/bin/shrinkray", line 4, in <module>
    from shrinkray.__main__ import main
  File "../shrinkray/__main__.py", line 25, in <module>
    import urwid.raw_display
ModuleNotFoundError: No module named 'urwid.raw_display'
```