### PR TITLE
ci: Separate coverage job, add resolution matrix, and daily schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # Run daily at 06:00 UTC
+    - cron: '0 6 * * *'
 
 jobs:
   action-lint:
@@ -55,6 +58,7 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
         # creduce package is broken on Ubuntu 24.04, so we use 22.04
         os: [ubuntu-22.04, macos-latest]
+        resolution: [highest, lowest-direct]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -77,18 +81,37 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install minisat creduce
       - name: Install Python dependencies
+        run: uv sync --extra dev --resolution ${{ matrix.resolution }}
+      - name: Run fast tests
+        run: uv run pytest tests/ -m "not slow" -q
+
+  coverage:
+    permissions:
+      contents: read
+    # creduce package is broken on Ubuntu 24.04, so we use 22.04
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
+        with:
+          version: "latest"
+      - name: Set up Python 3.13
+        run: uv python install 3.13
+      - name: Pin Python version
+        run: uv python pin 3.13
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y minisat creduce
+      - name: Install Python dependencies
         run: uv sync --extra dev
       - name: Run fast tests with coverage
-        # We hit weird bugs with coverage on 3.14 that we've (ironically)
-        # not yet adequately minimised to reproduce and file upstream, so
-        # we disable coverage on 3.14 for now.
-        if: matrix.python-version != '3.14'
         run: |
           uv run coverage run -m pytest tests/ -m "not slow" -q
           uv run coverage report --show-missing --fail-under=100
-      - name: Run fast tests without coverage (Python 3.14)
-        if: matrix.python-version == '3.14'
-        run: uv run pytest tests/ -m "not slow" -q
 
   slow-tests:
     permissions:
@@ -126,7 +149,7 @@ jobs:
   auto-release:
     # Only run on main branch, after all CI checks pass
     if: github.ref == 'refs/heads/main'
-    needs: [action-lint, lint, test, slow-tests]
+    needs: [action-lint, lint, test, coverage, slow-tests]
     runs-on: ubuntu-22.04
     permissions:
       contents: write  # Needed to push commits and tags

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
         # creduce package is broken on Ubuntu 24.04, so we use 22.04
         os: [ubuntu-22.04, macos-latest]
+        # Test with both newest deps (highest) and oldest supported deps (lowest-direct)
         resolution: [highest, lowest-direct]
     runs-on: ${{ matrix.os }}
     steps:
@@ -98,6 +99,9 @@ jobs:
         uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
         with:
           version: "latest"
+      # We use 3.13 for coverage because we hit weird bugs with coverage on 3.14
+      # that we've (ironically) not yet adequately minimised to reproduce and
+      # file upstream.
       - name: Set up Python 3.13
         run: uv python install 3.13
       - name: Pin Python version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "libcst>=1.1.0",
     "exceptiongroup>=1.2.0",
     "binaryornot>=0.4.4",
-    "black",
+    "black>=24.1.0",
 ]
 
 [project.urls]
@@ -35,17 +35,17 @@ shrinkray-worker = "shrinkray.__main__:worker_main"
 
 [project.optional-dependencies]
 dev = [
-    "coverage>=7.13.0",
+    "coverage>=7.4.0",
     "hypothesis>=6.92.1",
     "hypothesmith>=0.3.1",
-    "pytest",
-    "pytest-trio",
-    "pytest-asyncio",
-    "pytest-textual-snapshot",
-    "coverage[toml]",
-    "pygments",
-    "basedpyright",
-    "ruff",
+    "pytest>=8.0.0",
+    "pytest-trio>=0.8.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-textual-snapshot>=1.0.0",
+    "coverage[toml]>=7.4.0",
+    "pygments>=2.17.0",
+    "basedpyright>=1.1.0",
+    "ruff>=0.1.0",
     "pexpect>=4.9.0",
     "pyte>=0.8.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -18,14 +18,14 @@ wheels = [
 
 [[package]]
 name = "basedpyright"
-version = "1.36.1"
+version = "1.36.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodejs-wheel-binaries" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/32/29/d42d543a1637e692ac557bfc6d6fcf50e9a7061c1cb4da403378d6a70453/basedpyright-1.36.1.tar.gz", hash = "sha256:20c9a24e2a4c95d5b6d46c78a6b6c7e3dc7cbba227125256431d47c595b15fd4", size = 22834851, upload-time = "2025-12-11T14:55:47.463Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/8a/4c5d74314fe085f8f9b1a92b7c96e2a116651b6c7596e4def872d5d7abf0/basedpyright-1.36.2.tar.gz", hash = "sha256:b596b1a6e6006c7dfd483efc1d602574f238321e28f70bc66e87255784b70630", size = 22835798, upload-time = "2025-12-23T02:31:27.357Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/7f/f0133313bffa303d32aa74468981eb6b2da7fadda6247c9aa0aeab8391b1/basedpyright-1.36.1-py3-none-any.whl", hash = "sha256:3d738484fe9681cdfe35dd98261f30a9a7aec64208bc91f8773a9aaa9b89dd16", size = 11881725, upload-time = "2025-12-11T14:55:43.805Z" },
+    { url = "https://files.pythonhosted.org/packages/69/88/0aaac8e5062cd83434ce41fac844646d0f285b574cda0eeb732e916db22b/basedpyright-1.36.2-py3-none-any.whl", hash = "sha256:8dfd74fad77fcccc066ea0af5fd07e920b6f88cb1b403936aa78ab5aaef51526", size = 11882631, upload-time = "2025-12-23T02:31:24.537Z" },
 ]
 
 [[package]]
@@ -222,14 +222,14 @@ wheels = [
 
 [[package]]
 name = "hypothesis"
-version = "6.148.7"
+version = "6.148.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/5e/6a506e81d4dfefed2e838b6beaaae87b2e411dda3da0a3abf94099f194ae/hypothesis-6.148.7.tar.gz", hash = "sha256:b96e817e715c5b1a278411e3b9baf6d599d5b12207ba25e41a8f066929f6c2a6", size = 471199, upload-time = "2025-12-05T02:12:38.068Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/b3/e098d91195f121602bb3e4d00276cf1da0035df53e9deeb18115467d6da9/hypothesis-6.148.8.tar.gz", hash = "sha256:fa6b2ae029bc02f9d2d6c2257b0cbf2dc3782362457d2027a038ad7f4209c385", size = 471333, upload-time = "2025-12-23T01:46:25.052Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/55/fa5607e4a4af96dfa0e7efd81bbd130735cedd21aac70b25e06191bff92f/hypothesis-6.148.7-py3-none-any.whl", hash = "sha256:94dbd58ebf259afa3bafb1d3bf5761ac1bde6f1477de494798cbf7960aabbdee", size = 538127, upload-time = "2025-12-05T02:12:35.54Z" },
+    { url = "https://files.pythonhosted.org/packages/61/95/0742f59910074262e98d9f3bb0f7fb7a6b4bfb7e70b6d203eeb5625a6452/hypothesis-6.148.8-py3-none-any.whl", hash = "sha256:c1842f47f974d74661b3779a26032f8b91bc1eb30d84741714d3712d7f43e85e", size = 538280, upload-time = "2025-12-23T01:46:22.555Z" },
 ]
 
 [package.optional-dependencies]
@@ -789,26 +789,26 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "basedpyright", marker = "extra == 'dev'" },
+    { name = "basedpyright", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "binaryornot", specifier = ">=0.4.4" },
-    { name = "black" },
+    { name = "black", specifier = ">=24.1.0" },
     { name = "chardet", specifier = ">=5.2.0" },
     { name = "click", specifier = ">=8.0.1" },
-    { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.13.0" },
-    { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
+    { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.4.0" },
+    { name = "coverage", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "exceptiongroup", specifier = ">=1.2.0" },
     { name = "humanize", specifier = ">=4.9.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.92.1" },
     { name = "hypothesmith", marker = "extra == 'dev'", specifier = ">=0.3.1" },
     { name = "libcst", specifier = ">=1.1.0" },
     { name = "pexpect", marker = "extra == 'dev'", specifier = ">=4.9.0" },
-    { name = "pygments", marker = "extra == 'dev'" },
+    { name = "pygments", marker = "extra == 'dev'", specifier = ">=2.17.0" },
     { name = "pyte", marker = "extra == 'dev'", specifier = ">=0.8.2" },
-    { name = "pytest", marker = "extra == 'dev'" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'" },
-    { name = "pytest-textual-snapshot", marker = "extra == 'dev'" },
-    { name = "pytest-trio", marker = "extra == 'dev'" },
-    { name = "ruff", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
+    { name = "pytest-textual-snapshot", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "pytest-trio", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "textual", specifier = ">=0.47.0" },
     { name = "trio", specifier = ">=0.28.0" },
 ]


### PR DESCRIPTION
- Extract coverage checks into dedicated job running on Python 3.13
- Add resolution matrix (highest, lowest-direct) to test job for dependency compatibility testing
- Add daily scheduled run at 06:00 UTC on main branch
- Test job now runs without coverage (12 matrix combinations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)