### PR TITLE
Prevent "Event loop is closed" crash and slow Ctrl+Q exit

### DIFF
--- a/src/shrinkray/tui.py
+++ b/src/shrinkray/tui.py
@@ -1938,11 +1938,14 @@ class ShrinkRayApp(App[None]):
 
     async def action_quit(self) -> None:
         """Quit the application with graceful cancellation."""
+        self.update_status("Shutting down...")
         if self._client and not self._completed:
             try:
-                await self._client.cancel()
+                await self._client.close()
             except Exception:
                 pass  # Process may have already exited
+            # Prevent double-close in run_reduction's finally block
+            self._client = None
         self.exit()
 
     def action_show_pass_stats(self) -> None:


### PR DESCRIPTION
Makes sure to wait for resource cleanup before exiting, so as to avoid destructors running into problems when run after the event loop.

Also shortens some timeouts and adds some indication of quit behaviour.

Probably fixes #49 and #50.