### PR TITLE
Fix PyPI sdist missing test support files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include pytest.ini
+include justfile
+
+recursive-include tests *.py *.svg *.jinja2
+recursive-include scripts *.py


### PR DESCRIPTION
## Summary
- Adds `MANIFEST.in` to include test support files in the PyPI source distribution tarball
- Fixes `ModuleNotFoundError: No module named 'tests.helpers'` when running tests from the sdist

Closes #52

## What was missing

The sdist included `test_*.py` files (auto-discovered by setuptools) but was missing:
- `tests/__init__.py` — needed to make `tests` a package
- `tests/helpers.py` — shared test utilities imported by multiple test files
- `tests/conftest.py` — pytest configuration and fixtures
- `tests/pytest_textual_snapshot.py` — vendored snapshot plugin
- `tests/resources/` — test resource files (jinja2 templates)
- `tests/__snapshots__/` — TUI snapshot SVGs
- `pytest.ini` — pytest configuration (markers, plugins)
- `justfile` — build commands
- `scripts/` — lint and build scripts

## Test plan
- [x] Built sdist and verified all missing files are now included
- [x] All tests pass (1393 passed, 2 skipped)
- [x] Lints pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)