### PR TITLE
Prevent "directory not empty" crash

### DIFF
--- a/src/shrinkray/process.py
+++ b/src/shrinkray/process.py
@@ -14,6 +14,41 @@ def signal_group(sp: "trio.Process", sig: int) -> None:
     os.killpg(gid, sig)
 
 
+def _close_pipes_sync(sp: "trio.Process") -> None:
+    """Close all pipes on a process synchronously.
+
+    Trio process pipes are FdStream instances which have a fileno() method,
+    but the type annotations declare them as abstract SendStream/ReceiveStream.
+    We use getattr to access fileno() without upsetting the type checker.
+    """
+    for pipe in [sp.stdout, sp.stderr, sp.stdin]:
+        if pipe is None:
+            continue
+        fileno_fn = getattr(pipe, "fileno", None)
+        if fileno_fn is not None:
+            try:
+                os.close(fileno_fn())
+            except OSError:
+                pass
+
+
+def kill_process_group(sp: "trio.Process") -> None:
+    """Synchronously kill a process group.
+
+    Sends SIGKILL to the entire process group to clean up child processes.
+    This is needed because Trio only kills the direct child on cancellation,
+    but shell scripts often fork children that continue running.
+
+    Always attempts to kill the group even if the group leader (sp) has
+    already exited, because child processes in the group may still be alive.
+    """
+    _close_pipes_sync(sp)
+    try:
+        os.killpg(sp.pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+
+
 async def interrupt_wait_and_kill(sp: "trio.Process", delay: float = 0.1) -> None:
     """Interrupt a process, wait for it to exit, and kill it if necessary."""
     await trio.lowlevel.checkpoint()

--- a/src/shrinkray/state.py
+++ b/src/shrinkray/state.py
@@ -6,11 +6,11 @@ import random
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 from abc import ABC, abstractmethod
 from collections import deque
 from datetime import timedelta
-from tempfile import TemporaryDirectory
 from typing import Any
 
 import humanize
@@ -31,7 +31,7 @@ from shrinkray.problem import (
     ReductionProblem,
     sort_key_for_initial,
 )
-from shrinkray.process import interrupt_wait_and_kill
+from shrinkray.process import interrupt_wait_and_kill, kill_process_group
 from shrinkray.reducer import DirectoryShrinkRay, Reducer, ShrinkRay
 from shrinkray.work import Volume, WorkContext
 
@@ -224,7 +224,7 @@ class ShrinkRayState[TestCase](ABC):
     excluded_test_cases: set[bytes] | None = None
 
     # Temp directory for output capture (when not using TUI's output manager)
-    _output_tempdir: TemporaryDirectory | None = None
+    _output_tempdir: tempfile.TemporaryDirectory | None = None
 
     # Stores output from successful tests, keyed by test case bytes
     # This avoids race conditions when multiple tests run in parallel
@@ -263,7 +263,7 @@ class ShrinkRayState[TestCase](ABC):
 
         # Ensure we have an output manager for capturing test output
         if self.output_manager is None:
-            self._output_tempdir = TemporaryDirectory()
+            self._output_tempdir = tempfile.TemporaryDirectory()
             self.output_manager = OutputCaptureManager(
                 output_dir=self._output_tempdir.name
             )
@@ -389,6 +389,7 @@ class ShrinkRayState[TestCase](ABC):
             kwargs["stdout"] = subprocess.DEVNULL
             kwargs["stderr"] = subprocess.DEVNULL
 
+        sp = None
         try:
             async with trio.open_nursery() as nursery:
 
@@ -445,6 +446,16 @@ class ShrinkRayState[TestCase](ABC):
 
                 return result
         finally:
+            # Kill entire process group to clean up child processes.
+            # The subprocess uses setsid (preexec_fn=os.setsid), so child
+            # processes spawned by the interestingness test form a process
+            # group. Trio only kills the direct child on cancellation, but
+            # shell scripts often fork children that continue running and
+            # may write to the temp directory, causing cleanup failures.
+            # Always attempt this even if the direct child has exited,
+            # because group children may still be alive.
+            if sp is not None:
+                kill_process_group(sp)
             # Clean up output file handle and capture output immediately
             if output_file_handle is not None:
                 output_file_handle.close()
@@ -487,11 +498,15 @@ class ShrinkRayState[TestCase](ABC):
                 finally:
                     if os.path.exists(working):
                         if os.path.isdir(working):
-                            shutil.rmtree(working)
+                            shutil.rmtree(working, ignore_errors=True)
                         else:
-                            os.unlink(working)
+                            try:
+                                os.unlink(working)
+                            except OSError:
+                                pass
         else:
-            with TemporaryDirectory() as d:
+            d = tempfile.mkdtemp()
+            try:
                 working = os.path.join(d, self.base)
                 await self.write_test_case_to_file(working, test_case)
 
@@ -500,6 +515,8 @@ class ShrinkRayState[TestCase](ABC):
                     debug=debug,
                     cwd=d,
                 )
+            finally:
+                shutil.rmtree(d, ignore_errors=True)
 
     @abstractmethod
     async def format_data(self, test_case: TestCase) -> TestCase | None: ...

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -9,7 +9,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import trio
 
-from shrinkray.process import interrupt_wait_and_kill, signal_group
+from shrinkray.process import (
+    _close_pipes_sync,
+    interrupt_wait_and_kill,
+    kill_process_group,
+    signal_group,
+)
 
 
 # === signal_group tests ===
@@ -240,3 +245,151 @@ async def test_interrupt_wait_and_kill_skips_sigkill_if_process_exits_after_poll
     # SIGKILL should not have been sent since returncode became non-None
     # after the poll loop, skipping the SIGKILL branch
     assert not sigkill_sent[0]
+
+
+# === _close_pipes_sync tests ===
+
+
+def test_close_pipes_sync_closes_all_pipes():
+    mock_sp = MagicMock()
+    mock_sp.stdout = MagicMock()
+    mock_sp.stdout.fileno.return_value = 10
+    mock_sp.stderr = MagicMock()
+    mock_sp.stderr.fileno.return_value = 11
+    mock_sp.stdin = MagicMock()
+    mock_sp.stdin.fileno.return_value = 12
+
+    with patch("shrinkray.process.os.close") as mock_close:
+        _close_pipes_sync(mock_sp)
+
+    assert mock_close.call_count == 3
+    mock_close.assert_any_call(10)
+    mock_close.assert_any_call(11)
+    mock_close.assert_any_call(12)
+
+
+def test_close_pipes_sync_skips_none_pipes():
+    mock_sp = MagicMock()
+    mock_sp.stdout = None
+    mock_sp.stderr = None
+    mock_sp.stdin = None
+
+    # Should not raise
+    _close_pipes_sync(mock_sp)
+
+
+def test_close_pipes_sync_skips_pipes_without_fileno():
+    """Test that pipes without a fileno() method are silently skipped."""
+    mock_sp = MagicMock()
+    pipe_without_fileno = object()  # Has no fileno attribute
+    mock_sp.stdout = pipe_without_fileno
+    mock_sp.stderr = None
+    mock_sp.stdin = None
+
+    # Should not raise
+    _close_pipes_sync(mock_sp)
+
+
+def test_close_pipes_sync_handles_oserror():
+    mock_sp = MagicMock()
+    mock_sp.stdout = MagicMock()
+    mock_sp.stdout.fileno.return_value = 10
+    mock_sp.stderr = None
+    mock_sp.stdin = None
+
+    with patch("shrinkray.process.os.close", side_effect=OSError):
+        # Should not raise even if os.close fails
+        _close_pipes_sync(mock_sp)
+
+
+# === kill_process_group tests ===
+
+
+def test_kill_process_group_sends_sigkill_to_group():
+    """Test that kill_process_group sends SIGKILL to the process group."""
+    mock_sp = MagicMock()
+    mock_sp.pid = 12345
+    mock_sp.stdout = None
+    mock_sp.stderr = None
+    mock_sp.stdin = None
+
+    with patch("shrinkray.process.os.killpg") as mock_killpg:
+        kill_process_group(mock_sp)
+
+    mock_killpg.assert_called_once_with(12345, signal.SIGKILL)
+
+
+def test_kill_process_group_closes_pipes_before_killing():
+    """Test that pipes are closed before sending SIGKILL."""
+    mock_sp = MagicMock()
+    mock_sp.pid = 12345
+    mock_sp.stdout.fileno.return_value = 10
+    mock_sp.stderr.fileno.return_value = 11
+    mock_sp.stdin.fileno.return_value = 12
+
+    call_order = []
+
+    def tracking_close(fd):
+        call_order.append(f"close_{fd}")
+
+    def tracking_killpg(pid, sig):
+        call_order.append("killpg")
+
+    with (
+        patch("shrinkray.process.os.close", side_effect=tracking_close),
+        patch("shrinkray.process.os.killpg", side_effect=tracking_killpg),
+    ):
+        kill_process_group(mock_sp)
+
+    assert call_order.index("killpg") > call_order.index("close_10")
+
+
+def test_kill_process_group_handles_process_lookup_error():
+    """Test that ProcessLookupError from killpg is handled gracefully."""
+    mock_sp = MagicMock()
+    mock_sp.pid = 12345
+    mock_sp.stdout = None
+    mock_sp.stderr = None
+    mock_sp.stdin = None
+
+    with patch(
+        "shrinkray.process.os.killpg", side_effect=ProcessLookupError
+    ):
+        # Should not raise
+        kill_process_group(mock_sp)
+
+
+def test_kill_process_group_handles_permission_error():
+    """Test that PermissionError from killpg is handled gracefully."""
+    mock_sp = MagicMock()
+    mock_sp.pid = 12345
+    mock_sp.stdout = None
+    mock_sp.stderr = None
+    mock_sp.stdin = None
+
+    with patch(
+        "shrinkray.process.os.killpg", side_effect=PermissionError
+    ):
+        # Should not raise
+        kill_process_group(mock_sp)
+
+
+async def test_kill_process_group_with_real_process():
+    """Integration test: kill_process_group kills a real subprocess."""
+    sp = await trio.lowlevel.open_process(
+        [
+            sys.executable,
+            "-c",
+            "import time; time.sleep(100)",
+        ],
+        preexec_fn=os.setsid,
+    )
+
+    assert sp.poll() is None
+
+    kill_process_group(sp)
+
+    # Process should be dead
+    with trio.move_on_after(1):
+        await sp.wait()
+    assert sp.returncode is not None

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -352,9 +352,7 @@ def test_kill_process_group_handles_process_lookup_error():
     mock_sp.stderr = None
     mock_sp.stdin = None
 
-    with patch(
-        "shrinkray.process.os.killpg", side_effect=ProcessLookupError
-    ):
+    with patch("shrinkray.process.os.killpg", side_effect=ProcessLookupError):
         # Should not raise
         kill_process_group(mock_sp)
 
@@ -367,9 +365,7 @@ def test_kill_process_group_handles_permission_error():
     mock_sp.stderr = None
     mock_sp.stdin = None
 
-    with patch(
-        "shrinkray.process.os.killpg", side_effect=PermissionError
-    ):
+    with patch("shrinkray.process.os.killpg", side_effect=PermissionError):
         # Should not raise
         kill_process_group(mock_sp)
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -826,7 +826,7 @@ async def test_run_for_exit_code_in_place_cleanup_handles_unlink_error(
 ):
     """Test that in-place cleanup handles OSError from os.unlink gracefully."""
     script = tmp_path / "test.sh"
-    script.write_text('#!/bin/bash\nexit 0')
+    script.write_text("#!/bin/bash\nexit 0")
     script.chmod(0o755)
 
     target = tmp_path / "test.txt"
@@ -869,7 +869,7 @@ async def test_process_group_killed_on_cancellation(tmp_path, monkeypatch):
     """Test that the process group is killed when the task is cancelled."""
     script = tmp_path / "test.sh"
     # Script that sleeps forever
-    script.write_text('#!/bin/bash\nsleep 1000')
+    script.write_text("#!/bin/bash\nsleep 1000")
     script.chmod(0o755)
 
     target = tmp_path / "test.txt"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -821,6 +821,93 @@ async def test_run_for_exit_code_in_place_not_basename(tmp_path):
     assert exit_code == 0
 
 
+async def test_run_for_exit_code_in_place_cleanup_handles_unlink_error(
+    tmp_path, monkeypatch
+):
+    """Test that in-place cleanup handles OSError from os.unlink gracefully."""
+    script = tmp_path / "test.sh"
+    script.write_text('#!/bin/bash\nexit 0')
+    script.chmod(0o755)
+
+    target = tmp_path / "test.txt"
+    target.write_text("hello")
+
+    state = ShrinkRayStateSingleFile(
+        input_type=InputType.arg,
+        in_place=True,
+        test=[str(script)],
+        filename=str(target),
+        timeout=5.0,
+        base="test.txt",
+        parallelism=1,
+        initial=b"hello",
+        formatter="none",
+        trivial_is_error=True,
+        seed=0,
+        volume=Volume.quiet,
+        clang_delta_executable=None,
+        history_enabled=False,
+    )
+
+    import shrinkray.state as state_mod
+
+    original_unlink = os.unlink
+
+    def failing_unlink(path):
+        # Only fail on the temp working files, not other unlinks
+        if "test-" in str(path):
+            raise OSError("permission denied")
+        return original_unlink(path)
+
+    monkeypatch.setattr(state_mod.os, "unlink", failing_unlink)
+    # Should not raise despite unlink failure
+    exit_code = await state.run_for_exit_code(b"hello world")
+    assert exit_code == 0
+
+
+async def test_process_group_killed_on_cancellation(tmp_path, monkeypatch):
+    """Test that the process group is killed when the task is cancelled."""
+    script = tmp_path / "test.sh"
+    # Script that sleeps forever
+    script.write_text('#!/bin/bash\nsleep 1000')
+    script.chmod(0o755)
+
+    target = tmp_path / "test.txt"
+    target.write_text("hello")
+
+    state = ShrinkRayStateSingleFile(
+        input_type=InputType.arg,
+        in_place=False,
+        test=[str(script)],
+        filename=str(target),
+        timeout=100.0,
+        base="test.txt",
+        parallelism=1,
+        initial=b"hello",
+        formatter="none",
+        trivial_is_error=True,
+        seed=0,
+        volume=Volume.quiet,
+        clang_delta_executable=None,
+        history_enabled=False,
+    )
+
+    import shrinkray.state as state_mod
+    from shrinkray.process import kill_process_group as original_kill
+
+    kill_called = [False]
+
+    def tracking_kill(sp):
+        kill_called[0] = True
+        original_kill(sp)
+
+    monkeypatch.setattr(state_mod, "kill_process_group", tracking_kill)
+    with trio.move_on_after(0.5):
+        await state.run_for_exit_code(b"hello")
+
+    assert kill_called[0]
+
+
 # === Additional error path tests ===
 
 


### PR DESCRIPTION
When Trio cancels a task (because another parallel candidate succeeded), trio.run_process only kills the direct child subprocess. But interestingness tests are shell scripts that spawn children (cp, timeout, lua, etc.) via setsid. These orphaned children continue writing to the temp directory, causing shutil.rmtree to fail with "OSError: Directory not empty".

Added kill_process_group() which sends SIGKILL to the entire process group on exit from run_script_on_file. Also made temp directory cleanup robust with ignore_errors=True as defense-in-depth.

Fixes #57