### PR TITLE
Fix crashes in patch merging

### DIFF
--- a/src/shrinkray/passes/patching.py
+++ b/src/shrinkray/passes/patching.py
@@ -77,10 +77,12 @@ class PatchApplier[PatchType, TargetType]:
                 to_merge = len(self.__merge_queue)
 
                 async def can_merge(k):
-                    # find_large_integer doubles each time, and
-                    # if we call it then we know that can_merge(to_merge)
-                    # is False, so we should never hit this.
-                    assert k <= 2 * to_merge
+                    # More patches can come in while we're merging and it
+                    # ends up fiddly and unreliable if we try to merge
+                    # those as part of this pass, so we just skip them
+                    # and will handle them on the next pass.
+                    if k > to_merge:
+                        return False
                     try:
                         attempted_patch = self.__patches.combine(
                             base_patch,
@@ -91,7 +93,7 @@ class PatchApplier[PatchType, TargetType]:
                     with_patch_applied = self.__patches.apply(
                         attempted_patch, self.__initial_test_case
                     )
-                    if await self.__problem.is_reduction(with_patch_applied):
+                    if await self.__problem.is_interesting(with_patch_applied):
                         self.__current_patch = attempted_patch
                         return True
                     else:
@@ -101,6 +103,8 @@ class PatchApplier[PatchType, TargetType]:
                     merged = to_merge
                 else:
                     merged = await self.__problem.work.find_large_integer(can_merge)
+
+                assert merged <= to_merge
 
                 for _, _, send_result in self.__merge_queue[:merged]:
                     send_result.send_nowait(True)

--- a/tests/test_patching.py
+++ b/tests/test_patching.py
@@ -1,7 +1,13 @@
 """Unit tests for patching module."""
 
+import hashlib
+from collections import defaultdict
+from random import Random
+
 import pytest
 import trio
+from hypothesis import given, settings
+from hypothesis import strategies as st
 
 from shrinkray.passes.patching import (
     Conflict,
@@ -797,3 +803,137 @@ async def test_empty_patch_equals_base_in_merge(autojump_clock):
         nursery.start_soon(applier.try_apply_patch, [(1, 2)])  # Real patch
 
     assert len(problem.current_test_case) <= 5
+
+
+# =============================================================================
+# Issue #63: AssertionError in can_merge
+# https://github.com/DRMacIver/shrinkray/issues/63
+#
+# The assertions `k <= 2 * to_merge` and `merged <= to_merge` in
+# __possibly_become_merge_master can fail when:
+#
+# 1. can_merge(to_merge) returns False (entering find_large_integer)
+# 2. During find_large_integer, successful intermediate merges trigger
+#    reductions that clear the is_interesting cache
+# 3. can_merge(to_merge) is re-evaluated (cache miss) and the underlying
+#    non-deterministic test now returns True
+# 4. find_large_integer continues past to_merge, violating the assertions
+#
+# The root cause is that find_large_integer assumes its function argument
+# is monotonic, but can_merge is not monotonic when the interestingness
+# test is non-deterministic (as with real subprocess-based tests).
+#
+# The mechanism requires:
+# - A non-deterministic is_interesting (like a flaky subprocess test)
+# - Multiple items in the merge queue (to_merge >= 2)
+# - Successful intermediate merges (f(k) for k < to_merge) that clear cache
+# - The combined result (to_merge items) fails on first eval but passes
+#   on second eval (after cache clearing)
+# =============================================================================
+
+
+def _deterministic_content_hash(x: bytes) -> int:
+    """Deterministic hash for test content, unaffected by PYTHONHASHSEED."""
+    return int.from_bytes(hashlib.sha256(x).digest()[:4])
+
+
+def _make_flaky_is_interesting(initial):
+    """Create a non-deterministic is_interesting function for issue #63 tests.
+
+    Simulates a flaky subprocess test: for multi-byte deletion results,
+    ~50% fail on first evaluation (content-hash-based), but all re-evaluations
+    succeed. This models a subprocess that sometimes times out or hits a
+    race condition on the first run.
+    """
+    evaluation_count: dict[bytes, int] = defaultdict(int)
+
+    async def flaky_is_interesting(x: bytes) -> bool:
+        await trio.sleep(0.001)
+        evaluation_count[x] += 1
+        if len(x) >= len(initial) - 1:
+            return True
+        if evaluation_count[x] == 1:
+            return _deterministic_content_hash(x) % 2 == 0
+        return True
+
+    return flaky_is_interesting
+
+
+@given(data=st.data())
+@settings(deadline=None, max_examples=200)
+async def test_issue_63_hypothesis_nondeterministic(data):
+    """Property test: apply_patches must not raise AssertionError.
+
+    The internal assertions in PatchApplier.__possibly_become_merge_master
+    should hold regardless of how the interestingness test behaves. This
+    test generates random configurations with a non-deterministic
+    is_interesting function to search for assertion violations.
+
+    When can_merge(to_merge) fails on first eval but succeeds on re-eval
+    (after cache clearing from intermediate successful merges),
+    find_large_integer can return values > to_merge, violating the internal
+    assertions.
+    """
+    initial_size = data.draw(st.integers(min_value=10, max_value=40))
+    n_patches = data.draw(st.integers(min_value=3, max_value=min(12, initial_size)))
+    parallelism = data.draw(st.sampled_from([2, 3, 4, 6, 8]))
+    seed = data.draw(st.integers(min_value=0, max_value=2**32 - 1))
+
+    rng = Random(seed)
+    initial = bytes(rng.getrandbits(8) for _ in range(initial_size))
+
+    positions = sorted(rng.sample(range(initial_size), n_patches))
+    patches = [[(p, p + 1)] for p in positions]
+
+    problem = BasicReductionProblem(
+        initial=initial,
+        is_interesting=_make_flaky_is_interesting(initial),
+        work=WorkContext(parallelism=parallelism, random=Random(seed)),
+    )
+
+    await apply_patches(problem, Cuts(), patches)
+
+
+async def test_issue_63_concrete_k_le_2_to_merge(autojump_clock):
+    """Concrete reproduction of issue #63: assert k <= 2 * to_merge.
+
+    With a non-deterministic interestingness test, the merge master's
+    can_merge function can return True during find_large_integer for the
+    same input that previously returned False (after cache clearing from
+    intermediate successful merges). This causes find_large_integer to
+    probe k values beyond 2 * to_merge, hitting the assertion.
+
+    We try multiple seeds because the bug depends on trio's task scheduling
+    within each time tick, which is not fully deterministic. With enough
+    attempts, at least one will trigger the assertion.
+    """
+    triggered = False
+    for seed in range(50):
+        rng = Random(seed)
+        initial = bytes(rng.getrandbits(8) for _ in range(18))
+
+        positions = sorted(rng.sample(range(18), 10))
+        patches = [[(p, p + 1)] for p in positions]
+
+        problem = BasicReductionProblem(
+            initial=initial,
+            is_interesting=_make_flaky_is_interesting(initial),
+            work=WorkContext(parallelism=3, random=Random(seed)),
+        )
+
+        try:
+            await apply_patches(problem, Cuts(), patches)
+        except BaseExceptionGroup as exc:
+            # Check that it's the expected assertion error from issue #63
+            for e in exc.exceptions:
+                if isinstance(e, BaseExceptionGroup):
+                    for inner in e.exceptions:
+                        if isinstance(inner, AssertionError):
+                            triggered = True
+                elif isinstance(e, AssertionError):
+                    triggered = True
+            if triggered:
+                break
+            raise
+
+    assert triggered, "Expected AssertionError from issue #63 was not triggered"

--- a/tests/test_patching.py
+++ b/tests/test_patching.py
@@ -894,7 +894,7 @@ async def test_issue_63_hypothesis_nondeterministic(data):
     await apply_patches(problem, Cuts(), patches)
 
 
-@pytest.mark.parametrize('seed', range(50))
+@pytest.mark.parametrize("seed", range(50))
 async def test_issue_63_concrete_k_le_2_to_merge(autojump_clock, seed):
     rng = Random(seed)
     initial = bytes(rng.getrandbits(8) for _ in range(18))

--- a/tests/test_patching.py
+++ b/tests/test_patching.py
@@ -894,46 +894,18 @@ async def test_issue_63_hypothesis_nondeterministic(data):
     await apply_patches(problem, Cuts(), patches)
 
 
-async def test_issue_63_concrete_k_le_2_to_merge(autojump_clock):
-    """Concrete reproduction of issue #63: assert k <= 2 * to_merge.
+@pytest.mark.parametrize('seed', range(50))
+async def test_issue_63_concrete_k_le_2_to_merge(autojump_clock, seed):
+    rng = Random(seed)
+    initial = bytes(rng.getrandbits(8) for _ in range(18))
 
-    With a non-deterministic interestingness test, the merge master's
-    can_merge function can return True during find_large_integer for the
-    same input that previously returned False (after cache clearing from
-    intermediate successful merges). This causes find_large_integer to
-    probe k values beyond 2 * to_merge, hitting the assertion.
+    positions = sorted(rng.sample(range(18), 10))
+    patches = [[(p, p + 1)] for p in positions]
 
-    We try multiple seeds because the bug depends on trio's task scheduling
-    within each time tick, which is not fully deterministic. With enough
-    attempts, at least one will trigger the assertion.
-    """
-    triggered = False
-    for seed in range(50):
-        rng = Random(seed)
-        initial = bytes(rng.getrandbits(8) for _ in range(18))
+    problem = BasicReductionProblem(
+        initial=initial,
+        is_interesting=_make_flaky_is_interesting(initial),
+        work=WorkContext(parallelism=3, random=Random(seed)),
+    )
 
-        positions = sorted(rng.sample(range(18), 10))
-        patches = [[(p, p + 1)] for p in positions]
-
-        problem = BasicReductionProblem(
-            initial=initial,
-            is_interesting=_make_flaky_is_interesting(initial),
-            work=WorkContext(parallelism=3, random=Random(seed)),
-        )
-
-        try:
-            await apply_patches(problem, Cuts(), patches)
-        except BaseExceptionGroup as exc:
-            # Check that it's the expected assertion error from issue #63
-            for e in exc.exceptions:
-                if isinstance(e, BaseExceptionGroup):
-                    for inner in e.exceptions:
-                        if isinstance(inner, AssertionError):
-                            triggered = True
-                elif isinstance(e, AssertionError):
-                    triggered = True
-            if triggered:
-                break
-            raise
-
-    assert triggered, "Expected AssertionError from issue #63 was not triggered"
+    await apply_patches(problem, Cuts(), patches)


### PR DESCRIPTION
If patches came in while we were merging, we would sometimes run into problems where we successfully merged more than `to_merge` worth of patches and kept going. This would trigger some internal assertions.

The fix is just to not try to do that and to only ever merge as many patches as we intended to at the start. There are some slight inefficiencies here, but I struggle to imagine they'll ever matter in practice.

Fixes #63 