### PR TITLE
Adaptive timeouts for interestingness tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,7 @@ Main Process (asyncio/textual)     Subprocess (trio)
 2. **Cache clearing on reduction**: When a smaller test case is found, old cached results are no longer useful (derived from old test case)
 3. **View caching**: `problem.view(format)` caches parsed views to avoid redundant parsing
 4. **Speculative parallelism**: Multiple candidates tested concurrently; first success wins, others are "wasted" but harmless
+5. **Adaptive timeouts**: `AdaptiveTimeoutPolicy` (`adaptive_timeout.py`) chooses each test run's timeout from recent measured runtimes (user `--timeout` is the maximum). When reduction stalls with tests timing out it raises the timeout to look for slow reductions; cached timeout-failures carry a validity condition so they are retried after a raise, and reducers call `problem.attempt_unstick()` before terminating so a raised timeout can trigger another round.
 
 ## Development Process: Test-Driven Development
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,8 @@
   again if they don't. Reduction no longer ends while a raised timeout might
   still make progress.
 - `--timeout` now sets the maximum the adaptive timeout may reach rather than
-  a fixed timeout; `--timeout` <= 0 still disables timeouts entirely.
+  a fixed timeout. With `--timeout` <= 0 the adaptive timeout has no upper
+  bound: tests still get killed once they run well past recent runtimes, but
+  the timeout can always be raised again, so no candidate is permanently lost.
 - The TUI now shows the current test timeout and the fraction of recent test
   runs that timed out.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,13 @@
+- The timeout for interestingness tests now adapts to measured test runtimes
+  over the course of the run, instead of staying fixed at 10x the first run's
+  time. This speeds up reduction when tests get faster as the test case
+  shrinks, while staying robust to variable timings under parallel load.
+- When reduction stalls while tests are timing out, Shrink Ray now temporarily
+  raises the timeout (up to `--timeout`, or 5 minutes if unset) to check
+  whether slower test runs would unlock further reductions, and lowers it
+  again if they don't. Reduction no longer ends while a raised timeout might
+  still make progress.
+- `--timeout` now sets the maximum the adaptive timeout may reach rather than
+  a fixed timeout; `--timeout` <= 0 still disables timeouts entirely.
+- The TUI now shows the current test timeout and the fraction of recent test
+  runs that timed out.

--- a/notes/no-caching.md
+++ b/notes/no-caching.md
@@ -25,3 +25,14 @@ delta debugging, which has a very high chance of generating duplicates due to th
 its coarse grained passes decompose into multiple operations from its fine grained passes.
 Shrink Ray basically never does that (I don't think it actually works) so has few opportunities
 to generate duplicates.
+## Update: adaptive timeouts gave the cache a real job
+
+The adaptive timeout feature (2026-07) complicates the "just remove it" plan.
+When reduction stalls with tests timing out, the reducer raises the timeout and
+re-runs a full round of passes; candidates that previously *timed out* are
+retried (their cache entries carry a validity condition tied to the timeout
+they ran under), while candidates that completed are served from cache. Without
+the cache, each of those retry rounds would re-execute every candidate the
+passes regenerate, which is exactly the situation where test runs are at their
+most expensive. So if the cache is ever removed, the timeout-exploration
+machinery needs a different way to avoid re-running completed candidates.

--- a/src/shrinkray/__main__.py
+++ b/src/shrinkray/__main__.py
@@ -89,11 +89,13 @@ async def run_shrink_ray(
     default=None,
     type=click.FLOAT,
     help=(
-        "Time out subprocesses after this many seconds. If not specified, "
-        "runs the interestingness test once and sets timeout to 10x the "
-        "measured time (capped at 5 minutes). If set to <= 0 then no timeout "
-        "will be used. Any commands that time out will be treated as failing "
-        "the test"
+        "Maximum time in seconds to allow the interestingness test to run. "
+        "Shrink Ray adapts the actual timeout to measured test runtimes over "
+        "the course of the run, never exceeding this value (or 5 minutes if "
+        "not specified), and temporarily raises it again when reduction "
+        "stalls with tests timing out. If set to <= 0 then no timeout will "
+        "be used. Any commands that time out will be treated as failing the "
+        "test"
     ),
 )
 @click.option(

--- a/src/shrinkray/__main__.py
+++ b/src/shrinkray/__main__.py
@@ -93,9 +93,9 @@ async def run_shrink_ray(
         "Shrink Ray adapts the actual timeout to measured test runtimes over "
         "the course of the run, never exceeding this value (or 5 minutes if "
         "not specified), and temporarily raises it again when reduction "
-        "stalls with tests timing out. If set to <= 0 then no timeout will "
-        "be used. Any commands that time out will be treated as failing the "
-        "test"
+        "stalls with tests timing out. If set to <= 0 the adaptive timeout "
+        "has no upper bound. Any commands that time out will be treated as "
+        "failing the test"
     ),
 )
 @click.option(

--- a/src/shrinkray/adaptive_timeout.py
+++ b/src/shrinkray/adaptive_timeout.py
@@ -18,11 +18,13 @@ a timeout from them:
 
 - When reduction stalls while a significant fraction of runs are timing
   out, the policy explores upwards: it doubles the timeout (up to the
-  user-specified maximum, or a hardcoded cap if none was given) to see
-  whether the timeouts were hiding progress. Each doubling gets a budget
-  of runs; if raising the timeout stops producing timeouts without
-  producing reductions, or we run out of headroom, the timeout drops back
-  down and exploration is paused until the next successful reduction.
+  user-specified maximum, or a hardcoded cap if none was given; a
+  user-specified timeout of infinity means there is no bound and
+  exploration can always climb further) to see whether the timeouts were
+  hiding progress. Each doubling gets a budget of runs; if raising the
+  timeout stops producing timeouts without producing reductions, or we
+  run out of headroom, the timeout drops back down and exploration is
+  paused until the next successful reduction.
 
 - When the reducer runs out of things to try (`attempt_unstick`), any
   timeouts seen since the last reduction trigger the same upward
@@ -90,9 +92,10 @@ class AdaptiveTimeoutPolicy:
         default_cap: float = DEFAULT_TIMEOUT_CAP,
         rung_budget: int = RUNG_RUN_BUDGET,
     ) -> None:
-        # A user timeout of infinity means timeouts are disabled entirely,
-        # in which case there is nothing to adapt.
-        self.__enabled = user_timeout != math.inf
+        # A user timeout of infinity means no upper bound: the timeout
+        # still adapts to measured runtimes, and exploration may raise it
+        # indefinitely, so no candidate is ever permanently lost to a
+        # timeout.
         if user_timeout is None:
             self.__cap = default_cap
         else:
@@ -120,10 +123,6 @@ class AdaptiveTimeoutPolicy:
         self.__last_progress = clock()
 
     @property
-    def enabled(self) -> bool:
-        return self.__enabled
-
-    @property
     def cap(self) -> float:
         return self.__cap
 
@@ -136,15 +135,11 @@ class AdaptiveTimeoutPolicy:
 
     def current_timeout(self) -> float:
         """The timeout to use for the next test run."""
-        if not self.__enabled:
-            return math.inf
         self.__evaluate_exploration()
         return self.__rung_timeout(self.__level)
 
     def record_completion(self, runtime: float, *, interesting: bool) -> None:
         """Record a test run that finished (however it exited)."""
-        if not self.__enabled:
-            return
         self.__runtimes.append(runtime)
         if interesting:
             self.__interesting_runtimes.append(runtime)
@@ -154,8 +149,6 @@ class AdaptiveTimeoutPolicy:
 
     def record_timeout(self, timeout_used: float) -> None:
         """Record a test run that was killed at `timeout_used` seconds."""
-        if not self.__enabled:
-            return
         self.__timed_out_flags.append(True)
         if timeout_used < self.__cap:
             self.__timeouts_below_cap += 1
@@ -165,8 +158,6 @@ class AdaptiveTimeoutPolicy:
 
     def note_reduction(self) -> None:
         """Record that a successful reduction happened."""
-        if not self.__enabled:
-            return
         self.__last_progress = self.__clock()
         self.__timeouts_below_cap = 0
         self.__exploration_exhausted = False
@@ -179,7 +170,7 @@ class AdaptiveTimeoutPolicy:
         round of reduction may now make progress (previously cached
         timeout-failures become invalid and will be retried).
         """
-        if not self.__enabled or self.__exploration_exhausted:
+        if self.__exploration_exhausted:
             return False
         if self.__timeouts_below_cap > 0 and self.__rung_timeout(
             self.__level + 1
@@ -199,8 +190,6 @@ class AdaptiveTimeoutPolicy:
         A run that timed out at `timeout_used` would still time out at any
         timeout no larger than that, but might succeed at a larger one.
         """
-        if not self.__enabled:
-            return True
         return self.current_timeout() <= timeout_used
 
     def reset(self) -> None:

--- a/src/shrinkray/adaptive_timeout.py
+++ b/src/shrinkray/adaptive_timeout.py
@@ -1,0 +1,280 @@
+"""Adaptive timeouts for interestingness tests.
+
+Test runtime varies a lot over the course of a reduction: candidates
+usually get faster as the test case shrinks, but some reductions make the
+test dramatically slower (e.g. a loop that now takes many more iterations),
+and parallel load adds variance on top. A fixed timeout is either too tight
+(losing reductions to spurious timeouts) or too generous (wasting most of
+the run waiting for candidates that will never finish).
+
+AdaptiveTimeoutPolicy tracks recent test runtimes and continuously chooses
+a timeout from them:
+
+- The base timeout is a generous multiple of a high quantile of recent
+  completed runtimes, with an extra floor based on the slowest recent
+  *interesting* runs (interesting runs are the ones we can't afford to
+  lose, and uninteresting candidates often fail much faster than
+  interesting ones succeed).
+
+- When reduction stalls while a significant fraction of runs are timing
+  out, the policy explores upwards: it doubles the timeout (up to the
+  user-specified maximum, or a hardcoded cap if none was given) to see
+  whether the timeouts were hiding progress. Each doubling gets a budget
+  of runs; if raising the timeout stops producing timeouts without
+  producing reductions, or we run out of headroom, the timeout drops back
+  down and exploration is paused until the next successful reduction.
+
+- When the reducer runs out of things to try (`attempt_unstick`), any
+  timeouts seen since the last reduction trigger the same upward
+  exploration, so a reduction never ends while a raised timeout might
+  still unlock progress.
+
+Timeout results interact with result caching: a candidate that timed out
+at 5s might succeed at 10s, so cached timeout-failures are only valid
+while the current timeout is no larger than the timeout they ran under.
+`cached_timeout_valid` implements that check for the caching layer.
+"""
+
+import math
+import time
+from collections import deque
+from collections.abc import Callable
+
+
+# Hard cap on the timeout when the user didn't specify one.
+DEFAULT_TIMEOUT_CAP = 300.0
+# Never set the timeout below this, to avoid pathological behaviour on
+# very fast tests.
+MIN_TIMEOUT = 1.0
+
+# The base timeout is the larger of these two estimates, so it adapts to
+# the common case while staying safe for slow interesting runs.
+RUNTIME_MULTIPLIER = 10.0  # x the p90 of recent completed runtimes
+INTERESTING_MULTIPLIER = 5.0  # x the slowest recent interesting runtime
+RUNTIME_QUANTILE = 0.9
+
+# Window sizes for recent measurements. Interesting runs are much rarer
+# than ordinary completions, so their window is smaller to keep it recent.
+RUNTIME_WINDOW = 200
+INTERESTING_WINDOW = 20
+OUTCOME_WINDOW = 100
+
+# Stall-based exploration: don't explore until we have a meaningful amount
+# of data showing a meaningful rate of timeouts, and enough time has
+# passed since the last reduction (scaled up when the timeout itself is
+# long, since everything happens more slowly then).
+MIN_OUTCOMES_FOR_EXPLORATION = 20
+TIMEOUT_RATE_THRESHOLD = 0.05
+STALL_MIN_SECONDS = 20.0
+STALL_TIMEOUT_MULTIPLIER = 3.0
+
+# How many runs to allow at each raised timeout before deciding whether to
+# raise it further or give up.
+RUNG_RUN_BUDGET = 50
+
+
+class AdaptiveTimeoutPolicy:
+    """Chooses and adapts the timeout for interestingness test runs.
+
+    All decisions are made from data reported through `record_completion`,
+    `record_timeout` and `note_reduction`; the current choice is read with
+    `current_timeout`. The clock is injectable for testing.
+    """
+
+    def __init__(
+        self,
+        *,
+        user_timeout: float | None,
+        clock: Callable[[], float] = time.monotonic,
+        min_timeout: float = MIN_TIMEOUT,
+        default_cap: float = DEFAULT_TIMEOUT_CAP,
+        rung_budget: int = RUNG_RUN_BUDGET,
+    ) -> None:
+        # A user timeout of infinity means timeouts are disabled entirely,
+        # in which case there is nothing to adapt.
+        self.__enabled = user_timeout != math.inf
+        if user_timeout is None:
+            self.__cap = default_cap
+        else:
+            self.__cap = user_timeout
+        self.__clock = clock
+        self.__min_timeout = min_timeout
+        self.__rung_budget = rung_budget
+
+        self.__runtimes: deque[float] = deque(maxlen=RUNTIME_WINDOW)
+        self.__interesting_runtimes: deque[float] = deque(maxlen=INTERESTING_WINDOW)
+        # True for each recent run that timed out, False for completions.
+        self.__timed_out_flags: deque[bool] = deque(maxlen=OUTCOME_WINDOW)
+
+        # Exploration state: the current timeout is the base timeout
+        # doubled once per level.
+        self.__level = 0
+        self.__runs_at_level = 0
+        self.__timeouts_at_level = 0
+        # Set when exploration has been tried and didn't help; cleared by
+        # the next successful reduction.
+        self.__exploration_exhausted = False
+        # Timeouts seen since the last reduction that happened below the
+        # cap (timeouts at the cap can't be helped by raising it).
+        self.__timeouts_below_cap = 0
+        self.__last_progress = clock()
+
+    @property
+    def enabled(self) -> bool:
+        return self.__enabled
+
+    @property
+    def cap(self) -> float:
+        return self.__cap
+
+    @property
+    def recent_timeout_rate(self) -> float:
+        """Fraction of recent runs that timed out."""
+        if not self.__timed_out_flags:
+            return 0.0
+        return sum(self.__timed_out_flags) / len(self.__timed_out_flags)
+
+    def current_timeout(self) -> float:
+        """The timeout to use for the next test run."""
+        if not self.__enabled:
+            return math.inf
+        self.__evaluate_exploration()
+        return self.__rung_timeout(self.__level)
+
+    def record_completion(self, runtime: float, *, interesting: bool) -> None:
+        """Record a test run that finished (however it exited)."""
+        if not self.__enabled:
+            return
+        self.__runtimes.append(runtime)
+        if interesting:
+            self.__interesting_runtimes.append(runtime)
+        self.__timed_out_flags.append(False)
+        if self.__level > 0:
+            self.__runs_at_level += 1
+
+    def record_timeout(self, timeout_used: float) -> None:
+        """Record a test run that was killed at `timeout_used` seconds."""
+        if not self.__enabled:
+            return
+        self.__timed_out_flags.append(True)
+        if timeout_used < self.__cap:
+            self.__timeouts_below_cap += 1
+        if self.__level > 0:
+            self.__runs_at_level += 1
+            self.__timeouts_at_level += 1
+
+    def note_reduction(self) -> None:
+        """Record that a successful reduction happened."""
+        if not self.__enabled:
+            return
+        self.__last_progress = self.__clock()
+        self.__timeouts_below_cap = 0
+        self.__exploration_exhausted = False
+        self.__reset_exploration()
+
+    def attempt_unstick(self) -> bool:
+        """Called when the reducer has run out of things to try.
+
+        Returns True if the timeout was raised, in which case another
+        round of reduction may now make progress (previously cached
+        timeout-failures become invalid and will be retried).
+        """
+        if not self.__enabled or self.__exploration_exhausted:
+            return False
+        if self.__timeouts_below_cap > 0 and self.__rung_timeout(
+            self.__level + 1
+        ) > self.__rung_timeout(self.__level):
+            self.__level += 1
+            self.__runs_at_level = 0
+            self.__timeouts_at_level = 0
+            return True
+        if self.__level > 0:
+            self.__reset_exploration()
+            self.__exploration_exhausted = True
+        return False
+
+    def cached_timeout_valid(self, timeout_used: float) -> bool:
+        """Whether a cached timeout-failure is still valid.
+
+        A run that timed out at `timeout_used` would still time out at any
+        timeout no larger than that, but might succeed at a larger one.
+        """
+        if not self.__enabled:
+            return True
+        return self.current_timeout() <= timeout_used
+
+    def reset(self) -> None:
+        """Discard all learned state (used when restarting reduction)."""
+        self.__runtimes.clear()
+        self.__interesting_runtimes.clear()
+        self.__timed_out_flags.clear()
+        self.__timeouts_below_cap = 0
+        self.__exploration_exhausted = False
+        self.__reset_exploration()
+        self.__last_progress = self.__clock()
+
+    def __reset_exploration(self) -> None:
+        self.__level = 0
+        self.__runs_at_level = 0
+        self.__timeouts_at_level = 0
+
+    def __clamp(self, value: float) -> float:
+        # The cap wins over the minimum: a user-specified maximum below
+        # the normal minimum timeout must still be respected.
+        return min(self.__cap, max(self.__min_timeout, value))
+
+    def __base_timeout(self) -> float:
+        """The timeout suggested by recent runtime measurements alone."""
+        if not self.__runtimes:
+            # No data: be maximally generous.
+            return self.__cap
+        sorted_runtimes = sorted(self.__runtimes)
+        index = min(
+            len(sorted_runtimes) - 1,
+            math.ceil(RUNTIME_QUANTILE * len(sorted_runtimes)),
+        )
+        candidate = RUNTIME_MULTIPLIER * sorted_runtimes[index]
+        if self.__interesting_runtimes:
+            candidate = max(
+                candidate, INTERESTING_MULTIPLIER * max(self.__interesting_runtimes)
+            )
+        return self.__clamp(candidate)
+
+    def __rung_timeout(self, level: int) -> float:
+        return self.__clamp(self.__base_timeout() * 2.0**level)
+
+    def __stall_threshold(self) -> float:
+        return max(STALL_MIN_SECONDS, STALL_TIMEOUT_MULTIPLIER * self.__rung_timeout(0))
+
+    def __evaluate_exploration(self) -> None:
+        """Advance the exploration state machine.
+
+        Called whenever the current timeout is read, so decisions are made
+        promptly (every test run reads the timeout before starting).
+        """
+        if self.__exploration_exhausted:
+            return
+        if self.__level == 0:
+            stalled = self.__clock() - self.__last_progress > self.__stall_threshold()
+            if (
+                stalled
+                and len(self.__timed_out_flags) >= MIN_OUTCOMES_FOR_EXPLORATION
+                and self.recent_timeout_rate >= TIMEOUT_RATE_THRESHOLD
+                and self.__rung_timeout(1) > self.__rung_timeout(0)
+            ):
+                self.__level = 1
+                self.__runs_at_level = 0
+                self.__timeouts_at_level = 0
+        elif self.__runs_at_level >= self.__rung_budget:
+            if self.__timeouts_at_level > 0 and self.__rung_timeout(
+                self.__level + 1
+            ) > self.__rung_timeout(self.__level):
+                # Still timing out with headroom left: raise further.
+                self.__level += 1
+                self.__runs_at_level = 0
+                self.__timeouts_at_level = 0
+            else:
+                # Raising the timeout didn't help: go back down and don't
+                # try again until something else changes.
+                self.__reset_exploration()
+                self.__exploration_exhausted = True

--- a/src/shrinkray/problem.py
+++ b/src/shrinkray/problem.py
@@ -548,6 +548,17 @@ class ReductionProblem[T](ABC):
     @abstractmethod
     def display(self, value: T) -> str: ...
 
+    async def attempt_unstick(self) -> bool:
+        """Called by reducers when a full round of reduction made no progress.
+
+        Returns True if something changed (e.g. the test timeout was raised,
+        invalidating cached timeout-failures) such that another round of
+        reduction might now make progress. The default implementation has
+        nothing to change.
+        """
+        await trio.lowlevel.checkpoint()
+        return False
+
     def backtrack(self, new_test_case: T) -> "ReductionProblem[T]":
         """Create a new problem starting from a different test case.
 
@@ -578,6 +589,21 @@ class ReductionProblem[T](ABC):
 
 class InvalidInitialExample(ValueError):
     pass
+
+
+@define
+class InterestingnessResult:
+    """The result of running the interestingness test on a candidate.
+
+    Interestingness predicates may return one of these instead of a plain
+    bool when the result should only be cached conditionally: `cache_valid`
+    is consulted on each cache hit and the result is re-tested once it
+    returns False. This is used for candidates that timed out, which might
+    succeed if retried under a larger timeout.
+    """
+
+    interesting: bool
+    cache_valid: Callable[[], bool] | None = None
 
 
 def default_cache_key(value: Any) -> str:
@@ -611,13 +637,14 @@ class BasicReductionProblem(ReductionProblem[T]):
     def __init__(
         self,
         initial: T,
-        is_interesting: Callable[[T], Awaitable[bool]],
+        is_interesting: Callable[[T], Awaitable[bool | InterestingnessResult]],
         work: WorkContext,
         sort_key: Callable[[T], Any] = default_sort_key,
         size: Callable[[T], int] = default_size,
         display: Callable[[T], str] = default_display,
         stats: ReductionStats | None = None,
         cache_key: Callable[[Any], str] = default_cache_key,
+        unstick: Callable[[], Awaitable[bool]] | None = None,
     ):
         super().__init__(work=work)
         self.__current = initial
@@ -631,9 +658,14 @@ class BasicReductionProblem(ReductionProblem[T]):
         else:
             self._stats = stats
 
-        self.__is_interesting_cache: dict[str, bool] = {}
+        # Maps cache keys to (result, cache_valid). Entries with a
+        # cache_valid function are only served while it returns True.
+        self.__is_interesting_cache: dict[
+            str, tuple[bool, Callable[[], bool] | None]
+        ] = {}
         self.__cache_key = cache_key
         self.__is_interesting = is_interesting
+        self.__unstick = unstick
         self.__on_reduce_callbacks: list[Callable[[T], Awaitable[None]]] = []
         self.__current = initial
         self.__has_set_up = False
@@ -642,10 +674,20 @@ class BasicReductionProblem(ReductionProblem[T]):
         if self.__has_set_up:
             return
         self.__has_set_up = True
-        if not await self.__is_interesting(self.current_test_case):
+        result, _ = await self.__run_is_interesting(self.current_test_case)
+        if not result:
             raise InvalidInitialExample(
                 f"Initial example ({self.display(self.current_test_case)}) does not satisfy interestingness test."
             )
+
+    async def __run_is_interesting(
+        self, test_case: T
+    ) -> tuple[bool, Callable[[], bool] | None]:
+        """Run the underlying predicate and normalize its result."""
+        outcome = await self.__is_interesting(test_case)
+        if isinstance(outcome, InterestingnessResult):
+            return outcome.interesting, outcome.cache_valid
+        return outcome, None
 
     def display(self, value: T) -> str:
         return self.__display(value)
@@ -665,6 +707,12 @@ class BasicReductionProblem(ReductionProblem[T]):
         call `fn` with the new value. Note that these are called outside the lock."""
         self.__on_reduce_callbacks.append(callback)
 
+    async def attempt_unstick(self) -> bool:
+        await trio.lowlevel.checkpoint()
+        if self.__unstick is None:
+            return False
+        return await self.__unstick()
+
     async def is_interesting(self, test_case: T) -> bool:
         """Returns true if this test_case is interesting."""
         await trio.lowlevel.checkpoint()
@@ -672,11 +720,13 @@ class BasicReductionProblem(ReductionProblem[T]):
             return True
         cache_key = self.__cache_key(test_case)
         try:
-            return self.__is_interesting_cache[cache_key]
+            cached_result, cache_valid = self.__is_interesting_cache[cache_key]
+            if cache_valid is None or cache_valid():
+                return cached_result
         except KeyError:
             pass
-        result = await self.__is_interesting(test_case)
-        self.__is_interesting_cache[cache_key] = result
+        result, cache_valid = await self.__run_is_interesting(test_case)
+        self.__is_interesting_cache[cache_key] = (result, cache_valid)
         self.stats.failed_reductions += 1
         self.stats.calls += 1
 
@@ -774,6 +824,9 @@ class View[S, T](ReductionProblem[T]):
             return await self.__problem.is_interesting(self.__dump(test_case))
         except DumpError:
             return False
+
+    async def attempt_unstick(self) -> bool:
+        return await self.__problem.attempt_unstick()
 
     def sort_key(self, test_case: T) -> Any:
         if self.__sort_key is not None:

--- a/src/shrinkray/reducer.py
+++ b/src/shrinkray/reducer.py
@@ -566,6 +566,10 @@ class ShrinkRay(Reducer[bytes]):
                 # worth trying before we give up for good.
                 if not await self.target.attempt_unstick():
                     break
+                # Something changed, so a pass that previously ran to
+                # completion without progress may now succeed on the same
+                # test case: no-progress fingerprints are no longer valid.
+                self.pass_fingerprints.clear()
 
 
 class UpdateKeys(Patches[dict[str, bytes], dict[str, bytes]]):

--- a/src/shrinkray/reducer.py
+++ b/src/shrinkray/reducer.py
@@ -561,7 +561,11 @@ class ShrinkRay(Reducer[bytes]):
             # Only terminate if no passes were skipped
             # If passes were skipped, we need another full run to be sure
             if not self._passes_were_skipped:
-                break
+                # Give the problem a chance to change something (e.g.
+                # raise an adaptive timeout) that makes another round
+                # worth trying before we give up for good.
+                if not await self.target.attempt_unstick():
+                    break
 
 
 class UpdateKeys(Patches[dict[str, bytes], dict[str, bytes]]):
@@ -625,11 +629,13 @@ class KeyProblem(ReductionProblem[bytes]):
 @define
 class DirectoryShrinkRay(Reducer[dict[str, bytes]]):
     async def run(self):
-        prev = None
-        while prev != self.target.current_test_case:
+        while True:
             prev = self.target.current_test_case
             await self.delete_keys()
             await self.shrink_values()
+            if self.target.current_test_case == prev:
+                if not await self.target.attempt_unstick():
+                    break
 
     async def delete_keys(self):
         target = self.target.current_test_case

--- a/src/shrinkray/state.py
+++ b/src/shrinkray/state.py
@@ -15,10 +15,12 @@ from collections import deque
 from datetime import timedelta
 from typing import Any
 
+import attrs
 import humanize
 import trio
 from attrs import define
 
+from shrinkray.adaptive_timeout import AdaptiveTimeoutPolicy
 from shrinkray.cli import InputType
 from shrinkray.formatting import default_reformat_data, determine_formatter_command
 from shrinkray.history import (
@@ -29,6 +31,7 @@ from shrinkray.history import (
 from shrinkray.passes.cpp import C_FILE_EXTENSIONS
 from shrinkray.problem import (
     BasicReductionProblem,
+    InterestingnessResult,
     InvalidInitialExample,
     ReductionProblem,
     sort_key_for_initial,
@@ -64,23 +67,23 @@ class MemoryLimitExceededOnInitial(InvalidInitialExample):
         )
 
 
-# Constants for dynamic timeout
+# The first call to the interestingness test is given generous headroom so
+# that we can measure its true runtime (and report clearly if it exceeds an
+# explicitly configured timeout) rather than killing it prematurely. When no
+# timeout was configured this fixed calibration timeout is used; afterwards
+# the AdaptiveTimeoutPolicy chooses timeouts from measured runtimes.
 DYNAMIC_TIMEOUT_CALIBRATION_TIMEOUT = 300.0  # 5 minutes for first call
-DYNAMIC_TIMEOUT_MULTIPLIER = 10
-DYNAMIC_TIMEOUT_MAX = 300.0  # 5 minutes maximum
-DYNAMIC_TIMEOUT_MIN = 1.0  # 1 second minimum to prevent edge cases
 
 
-def compute_dynamic_timeout(runtime: float) -> float:
-    """Compute dynamic timeout based on measured runtime.
+@define(frozen=True)
+class ScriptRunResult:
+    """The result of a single run of the interestingness test script."""
 
-    The timeout is set to 10x the measured runtime, clamped between
-    DYNAMIC_TIMEOUT_MIN and DYNAMIC_TIMEOUT_MAX.
-    """
-    return max(
-        DYNAMIC_TIMEOUT_MIN,
-        min(runtime * DYNAMIC_TIMEOUT_MULTIPLIER, DYNAMIC_TIMEOUT_MAX),
-    )
+    exit_code: int
+    # Whether the run was killed because it hit the timeout, and if so
+    # which timeout (in seconds) it was subject to.
+    timed_out: bool = False
+    timeout_used: float | None = None
 
 
 @define
@@ -220,7 +223,15 @@ class ShrinkRayState[TestCase](ABC):
     can_format: bool = True
     formatter_command: list[str] | None = None
 
-    first_call_time: float | None = None
+    # Chooses the timeout for each interestingness test run, adapting to
+    # measured runtimes. `timeout` (the user-specified value) acts as its
+    # maximum. Injectable for testing.
+    timeout_policy: AdaptiveTimeoutPolicy = attrs.field(
+        default=attrs.Factory(
+            lambda self: AdaptiveTimeoutPolicy(user_timeout=self.timeout),
+            takes_self=True,
+        )
+    )
 
     # Stores the output from the last debug run
     _last_debug_output: str = ""
@@ -411,7 +422,7 @@ class ShrinkRayState[TestCase](ABC):
 
     async def run_script_on_file(
         self, working: str, cwd: str, debug: bool = False
-    ) -> int:
+    ) -> ScriptRunResult:
         if not os.path.exists(working):
             raise ValueError(f"No such file {working}")
         if self.input_type.enabled(InputType.arg):
@@ -450,9 +461,6 @@ class ShrinkRayState[TestCase](ABC):
 
             if self.first_call:
                 self.initial_exit_code = completed.returncode
-                # Set dynamic timeout if not explicitly specified
-                if self.timeout is None:
-                    self.timeout = compute_dynamic_timeout(runtime)
                 self.first_call = False
                 self.raise_if_initial_over_memory()
             else:
@@ -466,7 +474,7 @@ class ShrinkRayState[TestCase](ABC):
                 output_parts.append(completed.stderr.decode("utf-8", errors="replace"))
             self._last_debug_output = "\n".join(output_parts).strip()
 
-            return completed.returncode
+            return ScriptRunResult(exit_code=completed.returncode)
 
         # Determine output handling
         test_id: int | None = None
@@ -508,18 +516,22 @@ class ShrinkRayState[TestCase](ABC):
                         else:
                             effective_timeout = self.timeout * 10
                     else:
-                        # For subsequent calls, timeout must be set (either explicit or computed)
-                        assert self.timeout is not None
-                        effective_timeout = self.timeout
+                        effective_timeout = self.timeout_policy.current_timeout()
 
                     with trio.move_on_after(effective_timeout):
                         await sp.wait()
 
                     runtime = time.time() - start_time
+                    timed_out = sp.returncode is None
 
-                    if sp.returncode is None:
+                    if timed_out:
                         # Process didn't terminate before timeout - kill it
                         await interrupt_wait_and_kill(sp)
+                        self.timeout_policy.record_timeout(effective_timeout)
+                    else:
+                        self.timeout_policy.record_completion(
+                            runtime, interesting=sp.returncode == 0
+                        )
 
                     # Check for timeout violation (only when timeout is explicitly set)
                     if (
@@ -537,17 +549,17 @@ class ShrinkRayState[TestCase](ABC):
                 finally:
                     if self.first_call:
                         self.initial_exit_code = sp.returncode
-                        # Set dynamic timeout if not explicitly specified
-                        if self.timeout is None:
-                            runtime = time.time() - start_time
-                            self.timeout = compute_dynamic_timeout(runtime)
                     self.first_call = False
 
                 result: int | None = sp.returncode
                 assert result is not None
                 exit_code = result
 
-                return result
+                return ScriptRunResult(
+                    exit_code=result,
+                    timed_out=timed_out,
+                    timeout_used=effective_timeout if timed_out else None,
+                )
         finally:
             # Kill entire process group to clean up child processes.
             # The subprocess uses setsid (preexec_fn=os.setsid), so child
@@ -584,7 +596,9 @@ class ShrinkRayState[TestCase](ABC):
                     )
                 self.output_manager.mark_completed(test_id, recorded_code)
 
-    async def run_for_exit_code(self, test_case: TestCase, debug: bool = False) -> int:
+    async def run_for_result(
+        self, test_case: TestCase, debug: bool = False
+    ) -> ScriptRunResult:
         if self.in_place:
             if self.input_type == InputType.basename:
                 working = self.filename
@@ -660,10 +674,11 @@ class ShrinkRayState[TestCase](ABC):
         )
 
         problem: BasicReductionProblem[TestCase] = BasicReductionProblem(
-            is_interesting=self.is_interesting,
+            is_interesting=self.check_interesting,
             initial=self.initial,
             work=work,
             sort_key=sort_key_for_initial(self.initial),
+            unstick=self._attempt_unstick,
             **self.extra_problem_kwargs,
         )
 
@@ -697,8 +712,20 @@ class ShrinkRayState[TestCase](ABC):
             async with write_lock:
                 await self.write_test_case_to_file(self.filename, test_case)
 
+        # Progress resets the adaptive timeout's stall detection and any
+        # in-progress upward exploration of the timeout.
+        @problem.on_reduce
+        async def _(test_case: TestCase):
+            self.timeout_policy.note_reduction()
+
         self._cached_reducer = self.new_reducer(problem)
         return self._cached_reducer
+
+    async def _attempt_unstick(self) -> bool:
+        """Unstick hook for the reduction problem: raise the adaptive
+        timeout if timeouts may have been hiding possible reductions."""
+        await trio.lowlevel.checkpoint()
+        return self.timeout_policy.attempt_unstick()
 
     @property
     def extra_problem_kwargs(self):
@@ -708,27 +735,42 @@ class ShrinkRayState[TestCase](ABC):
     def problem(self):
         return self.reducer.target
 
-    async def is_interesting(self, test_case: TestCase) -> bool:
+    async def check_interesting(self, test_case: TestCase) -> InterestingnessResult:
+        """Run the interestingness test on test_case.
+
+        The result carries caching metadata: runs that timed out are only
+        valid while the adaptive timeout is no larger than the timeout they
+        ran under, so that they are retried if the timeout is later raised.
+        """
         # Check exclusion set first (for restart-from-point feature)
         if self.excluded_test_cases is not None:
             test_case_bytes = self._get_test_case_bytes(test_case)
             if test_case_bytes in self.excluded_test_cases:
-                return False
+                return InterestingnessResult(interesting=False)
 
-        if self.first_call_time is None:
-            self.first_call_time = time.time()
         async with self.is_interesting_limiter:
-            exit_code = await self.run_for_exit_code(test_case)
-            self._check_also_interesting(exit_code, test_case)
-            if exit_code == 0:
+            result = await self.run_for_result(test_case)
+            self._check_also_interesting(result.exit_code, test_case)
+            if result.exit_code == 0:
                 # Capture output now while still in the limiter to avoid race conditions
                 # where another test starts and overwrites the "current" output
                 test_case_bytes = self._get_test_case_bytes(test_case)
                 output = self._get_last_captured_output()
                 if output is not None:
                     self._successful_outputs[test_case_bytes] = output
-                return True
-            return False
+                return InterestingnessResult(interesting=True)
+            if result.timed_out and result.timeout_used is not None:
+                timeout_used = result.timeout_used
+                return InterestingnessResult(
+                    interesting=False,
+                    cache_valid=lambda: self.timeout_policy.cached_timeout_valid(
+                        timeout_used
+                    ),
+                )
+            return InterestingnessResult(interesting=False)
+
+    async def is_interesting(self, test_case: TestCase) -> bool:
+        return (await self.check_interesting(test_case)).interesting
 
     def reset_for_restart(self, new_initial: bytes, excluded: set[bytes]) -> None:
         """Reset state for restart from a history point.
@@ -749,6 +791,9 @@ class ShrinkRayState[TestCase](ABC):
             pass
         # Clear stored successful outputs (no longer relevant after restart)
         self._successful_outputs.clear()
+        # Forget learned timeout state: the restart point may be much
+        # slower than what the timeout had adapted down to.
+        self.timeout_policy.reset()
         # Reset initial_exit_code - the new initial is known to be interesting
         # (it came from history) so its exit code was 0
         self.initial_exit_code = 0
@@ -847,7 +892,7 @@ class ShrinkRayState[TestCase](ABC):
             )
         else:
             lines.append("Rerunning the interestingness test for debugging purposes...")
-            exit_code = await self.run_for_exit_code(self.initial, debug=True)
+            exit_code = (await self.run_for_result(self.initial, debug=True)).exit_code
             if exit_code != 0:
                 lines.append(
                     f"This exited with code {exit_code}, but the script should "
@@ -857,22 +902,26 @@ class ShrinkRayState[TestCase](ABC):
                 if self._last_debug_output:
                     lines.append("\nOutput from the interestingness test:")
                     lines.append(self._last_debug_output)
-                local_exit_code = await self.run_script_on_file(
-                    working=self.filename,
-                    debug=False,
-                    cwd=os.getcwd(),
-                )
+                local_exit_code = (
+                    await self.run_script_on_file(
+                        working=self.filename,
+                        debug=False,
+                        cwd=os.getcwd(),
+                    )
+                ).exit_code
                 if local_exit_code == 0:
                     lines.append(
                         "\nNote that Shrink Ray runs your script on a copy of the file "
                         "in a temporary directory. Here are the results of running it "
                         "in the current directory..."
                     )
-                    other_exit_code = await self.run_script_on_file(
-                        working=self.filename,
-                        debug=True,
-                        cwd=os.getcwd(),
-                    )
+                    other_exit_code = (
+                        await self.run_script_on_file(
+                            working=self.filename,
+                            debug=True,
+                            cwd=os.getcwd(),
+                        )
+                    ).exit_code
                     # Include the output from running in current directory
                     if self._last_debug_output:
                         lines.append(self._last_debug_output)
@@ -987,26 +1036,6 @@ class ShrinkRayStateSingleFile(ShrinkRayState[bytes]):
     async def write_test_case_to_file_impl(self, working: str, test_case: bytes):
         async with await trio.open_file(working, "wb") as o:
             await o.write(test_case)
-
-    async def is_interesting(self, test_case: bytes) -> bool:
-        # Check exclusion set first (for restart-from-point feature)
-        if (
-            self.excluded_test_cases is not None
-            and test_case in self.excluded_test_cases
-        ):
-            return False
-
-        async with self.is_interesting_limiter:
-            exit_code = await self.run_for_exit_code(test_case)
-            self._check_also_interesting(exit_code, test_case)
-            if exit_code == 0:
-                # Capture output now while still in the limiter to avoid race conditions
-                # where another test starts and overwrites the "current" output
-                output = self._get_last_captured_output()
-                if output is not None:
-                    self._successful_outputs[test_case] = output
-                return True
-            return False
 
     async def print_exit_message(self, problem):
         formatting_increase = 0

--- a/src/shrinkray/subprocess/protocol.py
+++ b/src/shrinkray/subprocess/protocol.py
@@ -45,6 +45,11 @@ class ProgressUpdate:
     effective_parallelism: float = 0.0
     # Time since last reduction
     time_since_last_reduction: float = 0.0
+    # Current adaptive timeout for test runs in seconds (None if timeouts
+    # are disabled or unknown)
+    current_timeout: float | None = None
+    # Fraction of recent test runs that timed out
+    timeout_rate: float = 0.0
     # Content preview (truncated for large files)
     content_preview: str = ""
     # Whether content is hex mode
@@ -112,6 +117,8 @@ def serialize(msg: Request | Response | ProgressUpdate) -> str:
                 "average_parallelism": msg.average_parallelism,
                 "effective_parallelism": msg.effective_parallelism,
                 "time_since_last_reduction": msg.time_since_last_reduction,
+                "current_timeout": msg.current_timeout,
+                "timeout_rate": msg.timeout_rate,
                 "content_preview": msg.content_preview,
                 "hex_mode": msg.hex_mode,
                 "pass_stats": [
@@ -175,6 +182,8 @@ def deserialize(line: str) -> Request | Response | ProgressUpdate:
             average_parallelism=d.get("average_parallelism", 0.0),
             effective_parallelism=d.get("effective_parallelism", 0.0),
             time_since_last_reduction=d.get("time_since_last_reduction", 0.0),
+            current_timeout=d.get("current_timeout"),
+            timeout_rate=d.get("timeout_rate", 0.0),
             content_preview=d.get("content_preview", ""),
             hex_mode=d.get("hex_mode", False),
             pass_stats=pass_stats_data,

--- a/src/shrinkray/subprocess/worker.py
+++ b/src/shrinkray/subprocess/worker.py
@@ -1,5 +1,6 @@
 """Worker subprocess that runs the reducer with trio and communicates via JSON protocol."""
 
+import math
 import os
 import shutil
 import signal
@@ -628,11 +629,14 @@ class ReducerWorker:
             history_dir = self.state.history_manager.history_dir
             target_basename = self.state.history_manager.target_basename
 
-        # Adaptive timeout stats
+        # Adaptive timeout stats. An infinite timeout (no runtime data yet,
+        # or timeouts unbounded and unraised) is reported as "unknown".
         current_timeout: float | None = None
         timeout_rate = 0.0
-        if self.state is not None and self.state.timeout_policy.enabled:
-            current_timeout = self.state.timeout_policy.current_timeout()
+        if self.state is not None:
+            policy_timeout = self.state.timeout_policy.current_timeout()
+            if math.isfinite(policy_timeout):
+                current_timeout = policy_timeout
             timeout_rate = self.state.timeout_policy.recent_timeout_rate
 
         return ProgressUpdate(

--- a/src/shrinkray/subprocess/worker.py
+++ b/src/shrinkray/subprocess/worker.py
@@ -628,6 +628,13 @@ class ReducerWorker:
             history_dir = self.state.history_manager.history_dir
             target_basename = self.state.history_manager.target_basename
 
+        # Adaptive timeout stats
+        current_timeout: float | None = None
+        timeout_rate = 0.0
+        if self.state is not None and self.state.timeout_policy.enabled:
+            current_timeout = self.state.timeout_policy.current_timeout()
+            timeout_rate = self.state.timeout_policy.recent_timeout_rate
+
         return ProgressUpdate(
             status=self.reducer.status if self.reducer else "",
             size=stats.current_test_case_size,
@@ -641,6 +648,8 @@ class ReducerWorker:
             average_parallelism=average_parallelism,
             effective_parallelism=effective_parallelism,
             time_since_last_reduction=stats.time_since_last_reduction(),
+            current_timeout=current_timeout,
+            timeout_rate=timeout_rate,
             content_preview=content_preview,
             hex_mode=hex_mode,
             pass_stats=pass_stats_list,

--- a/src/shrinkray/tui.py
+++ b/src/shrinkray/tui.py
@@ -161,6 +161,8 @@ class StatsDisplay(Static):
     average_parallelism = reactive(0.0)
     effective_parallelism = reactive(0.0)
     time_since_last_reduction = reactive(0.0)
+    current_timeout: reactive[float | None] = reactive(None)
+    timeout_rate = reactive(0.0)
 
     def update_stats(self, update: ProgressUpdate) -> None:
         self.current_status = update.status
@@ -175,6 +177,8 @@ class StatsDisplay(Static):
         self.average_parallelism = update.average_parallelism
         self.effective_parallelism = update.effective_parallelism
         self.time_since_last_reduction = update.time_since_last_reduction
+        self.current_timeout = update.current_timeout
+        self.timeout_rate = update.timeout_rate
         self.refresh(layout=True)
 
     def render(self) -> str:
@@ -218,6 +222,13 @@ class StatsDisplay(Static):
             )
         else:
             lines.append("Not yet called interestingness test")
+
+        # Adaptive test timeout
+        if self.current_timeout is not None:
+            lines.append(
+                f"Test timeout: {self.current_timeout:.1f}s "
+                f"({self.timeout_rate * 100.0:.0f}% of recent tests timed out)"
+            )
 
         # Time since last reduction
         if self.reduction_count > 0 and self.runtime > 0:

--- a/tests/test_adaptive_timeout.py
+++ b/tests/test_adaptive_timeout.py
@@ -1,0 +1,433 @@
+"""Tests for the adaptive timeout policy."""
+
+import math
+
+import pytest
+from hypothesis import example, given
+from hypothesis import strategies as st
+
+from shrinkray.adaptive_timeout import (
+    DEFAULT_TIMEOUT_CAP,
+    MIN_OUTCOMES_FOR_EXPLORATION,
+    MIN_TIMEOUT,
+    RUNG_RUN_BUDGET,
+    STALL_MIN_SECONDS,
+    AdaptiveTimeoutPolicy,
+)
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def make_policy(user_timeout=None, **kwargs) -> tuple[AdaptiveTimeoutPolicy, FakeClock]:
+    clock = FakeClock()
+    policy = AdaptiveTimeoutPolicy(user_timeout=user_timeout, clock=clock, **kwargs)
+    return policy, clock
+
+
+def record_fast_run_with_timeouts(policy, n_completions=50, n_timeouts=10):
+    """Record a mix of fast completions and timeouts (rate well over threshold)."""
+    for _ in range(n_completions):
+        policy.record_completion(0.1, interesting=False)
+    for _ in range(n_timeouts):
+        policy.record_timeout(policy.current_timeout())
+
+
+def trigger_exploration(policy, clock):
+    """Put the policy into a state where stall-based exploration has begun."""
+    policy.record_completion(0.1, interesting=True)
+    record_fast_run_with_timeouts(policy)
+    base = policy.current_timeout()
+    clock.advance(STALL_MIN_SECONDS + 1)
+    raised = policy.current_timeout()
+    assert raised == 2 * base
+    return base, raised
+
+
+# === basic configuration ===
+
+
+def test_disabled_when_user_timeout_is_infinite():
+    policy, _ = make_policy(user_timeout=math.inf)
+    assert not policy.enabled
+    assert policy.current_timeout() == math.inf
+    # Records are accepted but have no effect
+    policy.record_completion(1.0, interesting=True)
+    policy.record_timeout(5.0)
+    policy.note_reduction()
+    assert policy.current_timeout() == math.inf
+    assert not policy.attempt_unstick()
+    assert policy.cached_timeout_valid(2.0)
+
+
+def test_default_cap_when_no_user_timeout():
+    policy, _ = make_policy(user_timeout=None)
+    assert policy.enabled
+    assert policy.cap == DEFAULT_TIMEOUT_CAP
+    # No data yet: be maximally generous
+    assert policy.current_timeout() == DEFAULT_TIMEOUT_CAP
+
+
+def test_user_timeout_is_cap():
+    policy, _ = make_policy(user_timeout=7.0)
+    assert policy.cap == 7.0
+    assert policy.current_timeout() == 7.0
+
+
+# === base timeout computation ===
+
+
+def test_base_timeout_tracks_runtime():
+    policy, _ = make_policy()
+    policy.record_completion(2.0, interesting=True)
+    # 10x the observed runtime, same as the old dynamic timeout heuristic.
+    assert policy.current_timeout() == 20.0
+
+
+def test_base_timeout_clamped_to_minimum():
+    policy, _ = make_policy()
+    policy.record_completion(0.001, interesting=True)
+    assert policy.current_timeout() == MIN_TIMEOUT
+
+
+def test_base_timeout_clamped_to_cap():
+    policy, _ = make_policy()
+    policy.record_completion(100.0, interesting=True)
+    assert policy.current_timeout() == DEFAULT_TIMEOUT_CAP
+
+
+def test_base_timeout_uses_high_quantile_of_runtimes():
+    policy, _ = make_policy()
+    # Mostly fast runs with some slow ones: the slow tail should dominate.
+    for _ in range(90):
+        policy.record_completion(0.1, interesting=False)
+    for _ in range(10):
+        policy.record_completion(1.0, interesting=False)
+    # p90 is 1.0, so timeout should be 10.0, not 1.0.
+    assert policy.current_timeout() == 10.0
+
+
+def test_interesting_runtimes_keep_timeout_generous():
+    policy, _ = make_policy()
+    # Uninteresting candidates fail fast, but interesting ones are slow.
+    # The timeout must stay high enough for interesting runs.
+    policy.record_completion(2.0, interesting=True)
+    for _ in range(150):
+        policy.record_completion(0.01, interesting=False)
+    # 5x the slowest recent interesting runtime.
+    assert policy.current_timeout() == 10.0
+
+
+def test_timeout_adapts_down_as_tests_get_faster():
+    policy, _ = make_policy()
+    policy.record_completion(5.0, interesting=True)
+    slow = policy.current_timeout()
+    # As reduction progresses the test gets much faster and old
+    # measurements age out of the windows.
+    for _ in range(500):
+        policy.record_completion(0.05, interesting=True)
+    fast = policy.current_timeout()
+    assert fast < slow
+    assert fast == MIN_TIMEOUT
+
+
+# === stall-based exploration ===
+
+
+def test_raises_timeout_when_stalled_with_timeouts():
+    policy, clock = make_policy()
+    trigger_exploration(policy, clock)
+
+
+def test_no_exploration_without_timeouts():
+    policy, clock = make_policy()
+    policy.record_completion(0.1, interesting=True)
+    record_fast_run_with_timeouts(policy, n_completions=100, n_timeouts=0)
+    base = policy.current_timeout()
+    clock.advance(STALL_MIN_SECONDS + 1)
+    assert policy.current_timeout() == base
+
+
+def test_no_exploration_when_not_stalled():
+    policy, clock = make_policy()
+    policy.record_completion(0.1, interesting=True)
+    record_fast_run_with_timeouts(policy)
+    base = policy.current_timeout()
+    clock.advance(1.0)
+    assert policy.current_timeout() == base
+
+
+def test_no_exploration_with_too_few_outcomes():
+    policy, clock = make_policy()
+    policy.record_completion(0.1, interesting=True)
+    # Plenty of timeouts by rate, but not enough data overall.
+    for _ in range(MIN_OUTCOMES_FOR_EXPLORATION - 2):
+        policy.record_timeout(policy.current_timeout())
+    base = policy.current_timeout()
+    clock.advance(STALL_MIN_SECONDS + 1)
+    assert policy.current_timeout() == base
+
+
+def test_stall_threshold_scales_with_timeout():
+    policy, clock = make_policy(user_timeout=10000.0)
+    policy.record_completion(60.0, interesting=True)
+    record_fast_run_with_timeouts(policy, n_completions=50, n_timeouts=10)
+    base = policy.current_timeout()
+    # Well past the fixed minimum stall time, but when the timeout itself
+    # is long we should wait proportionally longer before concluding that
+    # reduction has stalled.
+    clock.advance(STALL_MIN_SECONDS + 1)
+    assert policy.current_timeout() == base
+
+
+def test_no_exploration_when_already_at_cap():
+    policy, clock = make_policy(user_timeout=1.5)
+    policy.record_completion(1.0, interesting=True)
+    record_fast_run_with_timeouts(policy)
+    assert policy.current_timeout() == 1.5
+    clock.advance(STALL_MIN_SECONDS + 1)
+    assert policy.current_timeout() == 1.5
+
+
+def test_exploration_capped_at_cap():
+    policy, clock = make_policy(user_timeout=2.5)
+    policy.record_completion(0.4, interesting=True)  # base 2.0
+    record_fast_run_with_timeouts(policy)
+    clock.advance(STALL_MIN_SECONDS + 1)
+    assert policy.current_timeout() == 2.5
+
+
+def test_exploration_advances_through_rungs_while_timeouts_continue():
+    policy, clock = make_policy()
+    base, _ = trigger_exploration(policy, clock)
+    # Timeouts continue at the raised timeout with no reduction: after the
+    # budget of runs at this rung we escalate further.
+    for _ in range(RUNG_RUN_BUDGET):
+        policy.record_timeout(policy.current_timeout())
+    assert policy.current_timeout() == 4 * base
+
+
+def test_exploration_reverts_when_raising_stops_timeouts_but_no_progress():
+    policy, clock = make_policy()
+    base, _ = trigger_exploration(policy, clock)
+    # At the raised timeout nothing times out any more, but nothing reduces
+    # either: raising didn't help, so go back down.
+    for _ in range(RUNG_RUN_BUDGET):
+        policy.record_completion(0.1, interesting=False)
+    assert policy.current_timeout() == base
+
+
+def test_failed_exploration_is_not_retried_until_reduction():
+    policy, clock = make_policy()
+    base, _ = trigger_exploration(policy, clock)
+    for _ in range(RUNG_RUN_BUDGET):
+        policy.record_completion(0.1, interesting=False)
+    assert policy.current_timeout() == base
+    # Conditions for exploration still hold, but we already tried and failed.
+    clock.advance(STALL_MIN_SECONDS + 1)
+    assert policy.current_timeout() == base
+    # A reduction resets this: exploration may trigger again later.
+    policy.note_reduction()
+    record_fast_run_with_timeouts(policy)
+    clock.advance(STALL_MIN_SECONDS + 1)
+    assert policy.current_timeout() == 2 * base
+
+
+def test_exploration_reverts_after_exhausting_all_rungs():
+    policy, clock = make_policy(user_timeout=4.0)
+    policy.record_completion(0.1, interesting=True)
+    record_fast_run_with_timeouts(policy)
+    base = policy.current_timeout()
+    assert base == MIN_TIMEOUT
+    clock.advance(STALL_MIN_SECONDS + 1)
+    # Climb: 2.0, 4.0 (cap), then nowhere left to go.
+    for expected in [2.0, 4.0]:
+        assert policy.current_timeout() == expected
+        for _ in range(RUNG_RUN_BUDGET):
+            policy.record_timeout(policy.current_timeout())
+    assert policy.current_timeout() == base
+
+
+def test_reduction_during_exploration_resets_and_keeps_timeout_generous():
+    policy, clock = make_policy()
+    base, _ = trigger_exploration(policy, clock)
+    # A slow interesting run completes at the raised timeout and a
+    # reduction follows.
+    slow_runtime = base * 1.5
+    policy.record_completion(slow_runtime, interesting=True)
+    policy.note_reduction()
+    # Exploration ends, but the slow interesting runtime keeps the base
+    # comfortably above what the successful run needed.
+    assert policy.current_timeout() >= slow_runtime
+    assert policy.current_timeout() == 5 * slow_runtime
+
+
+# === attempt_unstick (reducer ran out of things to try) ===
+
+
+def test_unstick_raises_timeout_when_timeouts_were_seen():
+    policy, _ = make_policy()
+    policy.record_completion(0.5, interesting=True)  # base 5.0
+    policy.record_timeout(5.0)
+    assert policy.attempt_unstick()
+    assert policy.current_timeout() == 10.0
+
+
+def test_unstick_does_nothing_without_timeouts():
+    policy, _ = make_policy()
+    policy.record_completion(0.5, interesting=True)
+    assert not policy.attempt_unstick()
+    assert policy.current_timeout() == 5.0
+
+
+def test_unstick_climbs_to_cap_then_gives_up():
+    policy, _ = make_policy(user_timeout=18.0)
+    policy.record_completion(0.5, interesting=True)  # base 5.0
+    policy.record_timeout(5.0)
+    assert policy.attempt_unstick()  # 10.0
+    policy.record_timeout(10.0)
+    assert policy.attempt_unstick()  # 18.0 (cap)
+    assert policy.current_timeout() == 18.0
+    policy.record_timeout(18.0)
+    assert not policy.attempt_unstick()
+    # After giving up we return to the base timeout.
+    assert policy.current_timeout() == 5.0
+
+
+def test_unstick_ignores_timeouts_at_cap():
+    policy, _ = make_policy(user_timeout=5.0)
+    policy.record_completion(0.5, interesting=True)  # base 5.0 == cap
+    policy.record_timeout(5.0)
+    assert not policy.attempt_unstick()
+
+
+def test_unstick_not_retried_after_exhaustion_until_reduction():
+    policy, _ = make_policy(user_timeout=8.0)
+    policy.record_completion(0.5, interesting=True)  # base 5.0
+    policy.record_timeout(5.0)
+    assert policy.attempt_unstick()  # 8.0 (cap)
+    assert not policy.attempt_unstick()
+    assert not policy.attempt_unstick()
+    policy.note_reduction()
+    policy.record_timeout(policy.current_timeout())
+    assert policy.attempt_unstick()
+
+
+def test_unstick_timeout_counter_resets_on_reduction():
+    policy, _ = make_policy()
+    policy.record_completion(0.5, interesting=True)
+    policy.record_timeout(5.0)
+    policy.note_reduction()
+    assert not policy.attempt_unstick()
+
+
+# === cache validity ===
+
+
+def test_cached_timeout_results_valid_at_or_below_recorded_timeout():
+    policy, _ = make_policy()
+    policy.record_completion(0.5, interesting=True)  # base 5.0
+    assert policy.cached_timeout_valid(5.0)
+    assert policy.cached_timeout_valid(10.0)
+
+
+def test_cached_timeout_results_invalidated_by_raise():
+    policy, _ = make_policy()
+    policy.record_completion(0.5, interesting=True)  # base 5.0
+    policy.record_timeout(5.0)
+    assert policy.attempt_unstick()
+    assert not policy.cached_timeout_valid(5.0)
+    assert policy.cached_timeout_valid(10.0)
+
+
+# === reset (restart from history) ===
+
+
+def test_reset_clears_learned_state():
+    policy, clock = make_policy()
+    trigger_exploration(policy, clock)
+    policy.reset()
+    # Back to knowing nothing: maximally generous.
+    assert policy.current_timeout() == DEFAULT_TIMEOUT_CAP
+    assert policy.recent_timeout_rate == 0.0
+
+
+# === stats ===
+
+
+def test_recent_timeout_rate():
+    policy, _ = make_policy()
+    assert policy.recent_timeout_rate == 0.0
+    for _ in range(8):
+        policy.record_completion(0.1, interesting=False)
+    for _ in range(2):
+        policy.record_timeout(policy.current_timeout())
+    assert policy.recent_timeout_rate == pytest.approx(0.2)
+
+
+# === property-based invariants ===
+
+
+@st.composite
+def policy_events(draw):
+    return draw(
+        st.lists(
+            st.one_of(
+                st.tuples(
+                    st.just("completion"),
+                    st.floats(min_value=0.0, max_value=1000.0),
+                    st.booleans(),
+                ),
+                st.just(("timeout",)),
+                st.just(("reduction",)),
+                st.just(("unstick",)),
+                st.tuples(
+                    st.just("advance"), st.floats(min_value=0.0, max_value=10000.0)
+                ),
+            ),
+            max_size=100,
+        )
+    )
+
+
+@given(
+    user_timeout=st.one_of(st.none(), st.floats(min_value=0.5, max_value=1000.0)),
+    events=policy_events(),
+)
+@example(
+    user_timeout=None,
+    events=[
+        ("completion", 1.0, True),
+        ("timeout",),
+        ("reduction",),
+        ("unstick",),
+        ("advance", 30.0),
+    ],
+)
+def test_current_timeout_always_within_bounds(user_timeout, events):
+    policy, clock = make_policy(user_timeout=user_timeout)
+    for event in events:
+        kind = event[0]
+        if kind == "completion":
+            policy.record_completion(event[1], interesting=event[2])
+        elif kind == "timeout":
+            policy.record_timeout(policy.current_timeout())
+        elif kind == "reduction":
+            policy.note_reduction()
+        elif kind == "unstick":
+            policy.attempt_unstick()
+        else:
+            assert kind == "advance"
+            clock.advance(event[1])
+        current = policy.current_timeout()
+        # The cap always wins, even when the user sets it below the
+        # normal minimum timeout.
+        assert min(MIN_TIMEOUT, policy.cap) <= current <= policy.cap

--- a/tests/test_adaptive_timeout.py
+++ b/tests/test_adaptive_timeout.py
@@ -55,22 +55,31 @@ def trigger_exploration(policy, clock):
 # === basic configuration ===
 
 
-def test_disabled_when_user_timeout_is_infinite():
+def test_infinite_user_timeout_still_adapts():
     policy, _ = make_policy(user_timeout=math.inf)
-    assert not policy.enabled
+    assert policy.cap == math.inf
+    # No data yet: no timeout at all.
     assert policy.current_timeout() == math.inf
-    # Records are accepted but have no effect
+    # But once we have runtime measurements, the timeout adapts as usual.
     policy.record_completion(1.0, interesting=True)
-    policy.record_timeout(5.0)
-    policy.note_reduction()
-    assert policy.current_timeout() == math.inf
-    assert not policy.attempt_unstick()
-    assert policy.cached_timeout_valid(2.0)
+    assert policy.current_timeout() == 10.0
+
+
+def test_unstick_climbs_without_bound_when_uncapped():
+    policy, _ = make_policy(user_timeout=math.inf)
+    policy.record_completion(0.5, interesting=True)  # base 5.0
+    # With no cap, exploration never runs out of headroom: a timed-out
+    # candidate is never permanently lost.
+    expected = 5.0
+    for _ in range(12):
+        policy.record_timeout(policy.current_timeout())
+        assert policy.attempt_unstick()
+        expected *= 2
+        assert policy.current_timeout() == expected
 
 
 def test_default_cap_when_no_user_timeout():
     policy, _ = make_policy(user_timeout=None)
-    assert policy.enabled
     assert policy.cap == DEFAULT_TIMEOUT_CAP
     # No data yet: be maximally generous
     assert policy.current_timeout() == DEFAULT_TIMEOUT_CAP
@@ -399,7 +408,11 @@ def policy_events(draw):
 
 
 @given(
-    user_timeout=st.one_of(st.none(), st.floats(min_value=0.5, max_value=1000.0)),
+    user_timeout=st.one_of(
+        st.none(),
+        st.just(math.inf),
+        st.floats(min_value=0.5, max_value=1000.0),
+    ),
     events=policy_events(),
 )
 @example(

--- a/tests/test_problem.py
+++ b/tests/test_problem.py
@@ -8,6 +8,7 @@ from shrinkray.problem import (
     BasicReductionProblem,
     DumpError,
     Format,
+    InterestingnessResult,
     InvalidInitialExample,
     ReductionProblem,
     ReductionStats,
@@ -932,3 +933,142 @@ async def test_abstract_method_default_implementations():
     # Test that is_interesting() calls base implementation (which is pass)
     result = await problem.is_interesting(b"hello")
     assert result is True  # Our implementation returns True after calling super
+
+
+# =============================================================================
+# InterestingnessResult caching tests
+# =============================================================================
+
+
+async def test_outcome_true_is_adopted_as_reduction():
+    async def is_interesting(x):
+        return InterestingnessResult(interesting=True)
+
+    problem = BasicReductionProblem(
+        initial=b"hello",
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+    )
+    assert await problem.is_interesting(b"hi") is True
+    assert problem.current_test_case == b"hi"
+
+
+async def test_outcome_false_is_cached_while_valid():
+    calls = [0]
+    valid = [True]
+
+    async def is_interesting(x):
+        calls[0] += 1
+        return InterestingnessResult(interesting=False, cache_valid=lambda: valid[0])
+
+    problem = BasicReductionProblem(
+        initial=b"hello",
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+    )
+    assert await problem.is_interesting(b"hi") is False
+    assert await problem.is_interesting(b"hi") is False
+    assert calls[0] == 1  # Cached while valid
+
+    valid[0] = False
+    assert await problem.is_interesting(b"hi") is False
+    assert calls[0] == 2  # Invalidated: re-tested
+
+
+async def test_invalidated_outcome_is_replaced_in_cache():
+    calls = [0]
+
+    async def is_interesting(x):
+        calls[0] += 1
+        if calls[0] == 1:
+            # First run: conditionally cacheable and immediately invalid.
+            return InterestingnessResult(interesting=False, cache_valid=lambda: False)
+        # Second run: unconditionally cacheable.
+        return InterestingnessResult(interesting=False)
+
+    problem = BasicReductionProblem(
+        initial=b"hello",
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+    )
+    assert await problem.is_interesting(b"hi") is False
+    assert await problem.is_interesting(b"hi") is False
+    assert calls[0] == 2
+    # The replacement entry is unconditional, so no further calls.
+    assert await problem.is_interesting(b"hi") is False
+    assert calls[0] == 2
+
+
+async def test_plain_bool_results_are_cached_unconditionally():
+    calls = [0]
+
+    async def is_interesting(x):
+        calls[0] += 1
+        return False
+
+    problem = BasicReductionProblem(
+        initial=b"hello",
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+    )
+    assert await problem.is_interesting(b"hi") is False
+    assert await problem.is_interesting(b"hi") is False
+    assert calls[0] == 1
+
+
+# =============================================================================
+# attempt_unstick tests
+# =============================================================================
+
+
+async def test_attempt_unstick_default_is_false():
+    async def is_interesting(x):
+        return True
+
+    problem = BasicReductionProblem(
+        initial=b"hello",
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+    )
+    assert await problem.attempt_unstick() is False
+
+
+async def test_attempt_unstick_calls_callback():
+    results = [True, False]
+
+    async def unstick():
+        return results.pop(0)
+
+    async def is_interesting(x):
+        return True
+
+    problem = BasicReductionProblem(
+        initial=b"hello",
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+        unstick=unstick,
+    )
+    assert await problem.attempt_unstick() is True
+    assert await problem.attempt_unstick() is False
+    assert results == []
+
+
+async def test_view_attempt_unstick_delegates():
+    unstick_calls = [0]
+
+    async def unstick():
+        unstick_calls[0] += 1
+        return True
+
+    async def is_interesting(x):
+        return True
+
+    problem = BasicReductionProblem(
+        initial=b"hello",
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+        unstick=unstick,
+    )
+    view = View(problem=problem, parse=lambda x: x, dump=lambda x: x)
+    assert await view.attempt_unstick() is True
+    assert unstick_calls[0] == 1

--- a/tests/test_reducer.py
+++ b/tests/test_reducer.py
@@ -7,7 +7,13 @@ import trio
 
 from shrinkray.passes.cpp import CPP_PASSES, CPP_PUMPS
 from shrinkray.passes.patching import PatchApplier
-from shrinkray.problem import BasicReductionProblem, Format, ParseError, shortlex
+from shrinkray.problem import (
+    BasicReductionProblem,
+    Format,
+    InterestingnessResult,
+    ParseError,
+    shortlex,
+)
 from shrinkray.reducer import (
     DirectoryShrinkRay,
     KeyProblem,
@@ -2163,3 +2169,110 @@ def test_default_tiers_reflect_measured_pass_value():
     assert not (polish_names & last_ditch_names)
     assert "tokenize/block_deletion(1, 20)" in last_ditch_names
     assert "tokenize/block_deletion(1, 20)" not in ok_names
+
+
+# =============================================================================
+# attempt_unstick integration tests
+# =============================================================================
+
+
+async def test_shrinkray_retries_after_successful_unstick():
+    """When the reducer runs out of progress, a successful attempt_unstick
+    causes another full round of reduction, which can then succeed."""
+    gate = [False]
+    unstick_calls = [0]
+
+    initial = b"hello world"
+
+    async def is_interesting(x):
+        if x == initial:
+            return True
+        if gate[0] and bool(x) and initial.startswith(x):
+            return True
+        # Like a timed-out run, this result may change if the gate opens,
+        # so it must only be cached while the gate stays as it was.
+        gate_at_run = gate[0]
+        return InterestingnessResult(
+            interesting=False, cache_valid=lambda: gate[0] == gate_at_run
+        )
+
+    async def unstick():
+        unstick_calls[0] += 1
+        if not gate[0]:
+            gate[0] = True
+            return True
+        return False
+
+    problem = BasicReductionProblem(
+        initial=initial,
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+        unstick=unstick,
+    )
+    reducer = ShrinkRay(target=problem)
+    await reducer.run()
+
+    assert problem.current_test_case == b"h"
+    # Called once to open the gate, then at least once more before
+    # terminating for real.
+    assert unstick_calls[0] >= 2
+
+
+async def test_shrinkray_terminates_when_unstick_fails():
+    unstick_calls = [0]
+
+    async def is_interesting(x):
+        return x == b"hello"
+
+    async def unstick():
+        unstick_calls[0] += 1
+        return False
+
+    problem = BasicReductionProblem(
+        initial=b"hello",
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+        unstick=unstick,
+    )
+    reducer = ShrinkRay(target=problem)
+    await reducer.run()
+
+    assert problem.current_test_case == b"hello"
+    assert unstick_calls[0] == 1
+
+
+async def test_directory_shrinkray_retries_after_successful_unstick():
+    gate = [False]
+    unstick_calls = [0]
+
+    initial = {"a.txt": b"aaa", "b.txt": b"bbb"}
+
+    async def is_interesting(x):
+        if x == initial:
+            return True
+        if gate[0] and x == {"a.txt": b"aaa"}:
+            return True
+        gate_at_run = gate[0]
+        return InterestingnessResult(
+            interesting=False, cache_valid=lambda: gate[0] == gate_at_run
+        )
+
+    async def unstick():
+        unstick_calls[0] += 1
+        if not gate[0]:
+            gate[0] = True
+            return True
+        return False
+
+    problem = BasicReductionProblem(
+        initial=initial,
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+        size=lambda d: sum(len(v) for v in d.values()),
+        unstick=unstick,
+    )
+    reducer = DirectoryShrinkRay(target=problem)
+    await reducer.run()
+
+    assert problem.current_test_case == {"a.txt": b"aaa"}
+    assert unstick_calls[0] >= 2

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1429,8 +1429,6 @@ async def test_attempt_format_with_formatter(tmp_path):
     assert state.can_format is False
 
 
-
-
 async def test_print_exit_message_formatting_increase(tmp_path, capsys):
     """Test print_exit_message when formatting increases size.
 
@@ -1550,8 +1548,6 @@ async def test_check_formatter_none(tmp_path):
     # check_formatter should return immediately without doing anything
     # (no exception, no side effects)
     await state.check_formatter()
-
-
 
 
 async def test_report_error_flaky_test(tmp_path, capsys):
@@ -4045,7 +4041,9 @@ async def test_reduction_notes_progress_to_policy(tmp_path):
     state = make_adaptive_state(tmp_path, "#!/bin/bash\nexit 0")
     problem = state.problem
     with patch.object(
-        state.timeout_policy, "note_reduction", wraps=state.timeout_policy.note_reduction
+        state.timeout_policy,
+        "note_reduction",
+        wraps=state.timeout_policy.note_reduction,
     ) as note:
         assert await problem.is_interesting(b"hello")
         note.assert_called_once()
@@ -4071,9 +4069,7 @@ if [ "$content" = "hello world" ]; then exit 0; fi
 if [ "$content" = "hello" ]; then sleep 0.4; exit 0; fi
 exit 1
 """
-    state = make_adaptive_state(
-        tmp_path, script_body, timeout=10.0, min_timeout=0.15
-    )
+    state = make_adaptive_state(tmp_path, script_body, timeout=10.0, min_timeout=0.15)
     await state.problem.setup()
     await state.reducer.run()
     assert state.problem.current_test_case == b"hello"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -10,13 +10,14 @@ import pytest
 import trio
 
 import shrinkray.state as state_mod
+from shrinkray.adaptive_timeout import MIN_TIMEOUT, AdaptiveTimeoutPolicy
 from shrinkray.cli import InputType
 from shrinkray.problem import InvalidInitialExample, shortlex
 from shrinkray.process import kill_process_group as original_kill
 from shrinkray.state import (
-    DYNAMIC_TIMEOUT_MIN,
     MemoryLimitExceededOnInitial,
     OutputCaptureManager,
+    ScriptRunResult,
     ShrinkRayDirectoryState,
     ShrinkRayStateSingleFile,
     TimeoutExceededOnInitial,
@@ -380,11 +381,11 @@ async def test_attempt_format_returns_data_when_cannot_format(tmp_path):
     assert result == b"test"
 
 
-# === run_for_exit_code tests ===
+# === run_for_result tests ===
 
 
-async def test_run_for_exit_code_returns_script_exit_code(tmp_path):
-    """Test that run_for_exit_code returns the script's exit code."""
+async def test_run_for_result_returns_script_exit_code(tmp_path):
+    """Test that run_for_result returns the script's exit code."""
     script = tmp_path / "test.sh"
     script.write_text("#!/bin/bash\nexit 42")
     script.chmod(0o755)
@@ -408,11 +409,11 @@ async def test_run_for_exit_code_returns_script_exit_code(tmp_path):
         history_enabled=False,
     )
 
-    exit_code = await state.run_for_exit_code(b"hello")
+    exit_code = (await state.run_for_result(b"hello")).exit_code
     assert exit_code == 42
 
 
-async def test_run_for_exit_code_with_stdin_input_type(tmp_path):
+async def test_run_for_result_with_stdin_input_type(tmp_path):
     """Test that stdin input type pipes data correctly."""
     # Script that exits 0 if stdin contains 'magic'
     script = tmp_path / "test.sh"
@@ -439,15 +440,15 @@ async def test_run_for_exit_code_with_stdin_input_type(tmp_path):
     )
 
     # Should exit 0 because stdin contains 'magic'
-    exit_code = await state.run_for_exit_code(b"magic word")
+    exit_code = (await state.run_for_result(b"magic word")).exit_code
     assert exit_code == 0
 
     # Should exit 1 because stdin doesn't contain 'magic'
-    exit_code = await state.run_for_exit_code(b"other word")
+    exit_code = (await state.run_for_result(b"other word")).exit_code
     assert exit_code == 1
 
 
-async def test_run_for_exit_code_in_place_mode(tmp_path):
+async def test_run_for_result_in_place_mode(tmp_path):
     """Test in_place mode writes to original file location."""
     script = tmp_path / "test.sh"
     script.write_text('#!/bin/bash\ncat "$1" | grep -q hello && exit 0 || exit 1')
@@ -473,7 +474,7 @@ async def test_run_for_exit_code_in_place_mode(tmp_path):
     )
 
     # Should exit 0 because file contains 'hello'
-    exit_code = await state.run_for_exit_code(b"hello there")
+    exit_code = (await state.run_for_result(b"hello there")).exit_code
     assert exit_code == 0
 
 
@@ -700,7 +701,7 @@ async def test_is_interesting_tracks_parallel_tasks(tmp_path):
 
 
 async def test_first_call_flag_is_cleared(tmp_path):
-    """Test that first_call flag is cleared after first run_for_exit_code call."""
+    """Test that first_call flag is cleared after first run_for_result call."""
     script = tmp_path / "test.sh"
     script.write_text("#!/bin/bash\nexit 0")
     script.chmod(0o755)
@@ -727,7 +728,7 @@ async def test_first_call_flag_is_cleared(tmp_path):
     # First call flag should be True initially
     assert state.first_call is True
 
-    await state.run_for_exit_code(b"hello")
+    await state.run_for_result(b"hello")
 
     # First call flag should be cleared after first call
     assert state.first_call is False
@@ -847,8 +848,8 @@ async def test_report_error_timeout_exceeded(tmp_path, capsys):
     assert "5.5" in captured.err or "5.50" in captured.err
 
 
-async def test_run_for_exit_code_no_input_type_arg(tmp_path):
-    """Test run_for_exit_code with input_type that doesn't include arg."""
+async def test_run_for_result_no_input_type_arg(tmp_path):
+    """Test run_for_result with input_type that doesn't include arg."""
     script = tmp_path / "test.sh"
     # Script that exits 0 always (testing that command is called without arg)
     script.write_text("#!/bin/bash\nexit 0")
@@ -874,12 +875,12 @@ async def test_run_for_exit_code_no_input_type_arg(tmp_path):
     )
 
     # Should run without the file argument
-    exit_code = await state.run_for_exit_code(b"hello")
+    exit_code = (await state.run_for_result(b"hello")).exit_code
     assert exit_code == 0
 
 
-async def test_run_for_exit_code_in_place_not_basename(tmp_path):
-    """Test run_for_exit_code in_place mode but not basename input type."""
+async def test_run_for_result_in_place_not_basename(tmp_path):
+    """Test run_for_result in_place mode but not basename input type."""
     script = tmp_path / "test.sh"
     script.write_text('#!/bin/bash\ntest -f "$1" && exit 0 || exit 1')
     script.chmod(0o755)
@@ -904,11 +905,11 @@ async def test_run_for_exit_code_in_place_not_basename(tmp_path):
     )
 
     # Should create a temporary file with unique name
-    exit_code = await state.run_for_exit_code(b"hello world")
+    exit_code = (await state.run_for_result(b"hello world")).exit_code
     assert exit_code == 0
 
 
-async def test_run_for_exit_code_in_place_cleanup_handles_unlink_error(
+async def test_run_for_result_in_place_cleanup_handles_unlink_error(
     tmp_path, monkeypatch
 ):
     """Test that in-place cleanup handles OSError from os.unlink gracefully."""
@@ -945,7 +946,7 @@ async def test_run_for_exit_code_in_place_cleanup_handles_unlink_error(
 
     monkeypatch.setattr(state_mod.os, "unlink", failing_unlink)
     # Should not raise despite unlink failure
-    exit_code = await state.run_for_exit_code(b"hello world")
+    exit_code = (await state.run_for_result(b"hello world")).exit_code
     assert exit_code == 0
 
 
@@ -983,7 +984,7 @@ async def test_process_group_killed_on_cancellation(tmp_path, monkeypatch):
 
     monkeypatch.setattr(state_mod, "kill_process_group", tracking_kill)
     with trio.move_on_after(0.5):
-        await state.run_for_exit_code(b"hello")
+        await state.run_for_result(b"hello")
 
     assert kill_called[0]
 
@@ -1018,7 +1019,7 @@ async def test_cancelled_test_is_not_recorded_as_exiting_with_code_zero(tmp_path
     state.output_manager = OutputCaptureManager(output_dir=str(tmp_path))
 
     with trio.move_on_after(0.5):
-        await state.run_for_exit_code(b"hello")
+        await state.run_for_result(b"hello")
 
     _, _, return_code = state.output_manager.get_current_output()
     assert return_code is not None
@@ -1054,7 +1055,7 @@ async def test_cleanup_when_process_never_started(tmp_path):
     )
 
     # Cancel immediately so nursery.start never completes and sp stays None.
-    # Call run_script_on_file directly because run_for_exit_code would be
+    # Call run_script_on_file directly because run_for_result would be
     # cancelled during write_test_case_to_file before reaching this code.
     with trio.CancelScope() as scope:
         scope.cancel()
@@ -1130,17 +1131,17 @@ async def test_report_error_cwd_dependent(tmp_path, capsys, monkeypatch):
         history_enabled=False,
     )
 
-    # Mock run_for_exit_code to fail (simulating temp dir failure)
-    original_run_for_exit_code = state.run_for_exit_code
+    # Mock run_for_result to fail (simulating temp dir failure)
+    original_run_for_result = state.run_for_result
 
-    async def mock_run_for_exit_code(test_case, debug=False):
+    async def mock_run_for_result(test_case, debug=False):
         call_count["value"] += 1
         if call_count["value"] == 1:
             # First call in report_error should fail
-            return 1
-        return await original_run_for_exit_code(test_case, debug)
+            return ScriptRunResult(exit_code=1)
+        return await original_run_for_result(test_case, debug)
 
-    monkeypatch.setattr(state, "run_for_exit_code", mock_run_for_exit_code)
+    monkeypatch.setattr(state, "run_for_result", mock_run_for_result)
 
     with pytest.raises(SystemExit):
         await state.report_error(ValueError("test error"))
@@ -1428,44 +1429,6 @@ async def test_attempt_format_with_formatter(tmp_path):
     assert state.can_format is False
 
 
-async def test_is_interesting_tracks_first_call_time(tmp_path):
-    """Test that is_interesting sets first_call_time on first call.
-
-    Exercises the first_call_time initialization in is_interesting.
-    """
-    script = tmp_path / "test.sh"
-    script.write_text("#!/bin/bash\nexit 0")
-    script.chmod(0o755)
-
-    target = tmp_path / "test.txt"
-    target.write_text("hello")
-
-    # Use ShrinkRayDirectoryState to test the base class is_interesting
-    # (ShrinkRayStateSingleFile has its own implementation)
-    state = ShrinkRayDirectoryState(
-        input_type=InputType.arg,
-        in_place=False,
-        test=[str(script)],
-        filename=str(target),
-        timeout=5.0,
-        base="test.txt",
-        parallelism=1,
-        initial={"a.txt": b"hello"},
-        formatter="none",
-        trivial_is_error=True,
-        seed=0,
-        volume=Volume.quiet,
-        history_enabled=False,
-    )
-
-    # first_call_time should be None initially
-    assert state.first_call_time is None
-
-    # Call is_interesting
-    await state.is_interesting({"a.txt": b"hello"})
-
-    # first_call_time should now be set
-    assert state.first_call_time is not None
 
 
 async def test_print_exit_message_formatting_increase(tmp_path, capsys):
@@ -1514,10 +1477,10 @@ async def test_print_exit_message_formatting_increase(tmp_path, capsys):
     assert "deleted" in captured.out.lower() or "increase" in captured.out.lower()
 
 
-async def test_run_for_exit_code_in_place_basename(tmp_path):
-    """Test run_for_exit_code in_place mode with basename input type.
+async def test_run_for_result_in_place_basename(tmp_path):
+    """Test run_for_result in_place mode with basename input type.
 
-    Exercises the in_place with basename input type path in run_for_exit_code.
+    Exercises the in_place with basename input type path in run_for_result.
     """
 
     # Change to tmp_path so the script can find the file by basename
@@ -1550,7 +1513,7 @@ async def test_run_for_exit_code_in_place_basename(tmp_path):
         )
 
         # Should write to the original filename and run the script
-        exit_code = await state.run_for_exit_code(b"hello world")
+        exit_code = (await state.run_for_result(b"hello world")).exit_code
         assert exit_code == 0
     finally:
         os.chdir(original_cwd)
@@ -1589,44 +1552,6 @@ async def test_check_formatter_none(tmp_path):
     await state.check_formatter()
 
 
-async def test_is_interesting_multiple_calls(tmp_path):
-    """Test is_interesting when called multiple times (first_call_time already set).
-
-    Exercises the skip path in is_interesting when first_call_time is already set.
-    """
-    script = tmp_path / "test.sh"
-    script.write_text("#!/bin/bash\nexit 0")
-    script.chmod(0o755)
-
-    target = tmp_path / "test.txt"
-    target.write_text("hello")
-
-    state = ShrinkRayDirectoryState(
-        input_type=InputType.arg,
-        in_place=False,
-        test=[str(script)],
-        filename=str(target),
-        timeout=5.0,
-        base="test.txt",
-        parallelism=1,
-        initial={"a.txt": b"hello"},
-        formatter="none",
-        trivial_is_error=True,
-        seed=0,
-        volume=Volume.quiet,
-        history_enabled=False,
-    )
-
-    # First call sets first_call_time
-    await state.is_interesting({"a.txt": b"hello"})
-    first_time = state.first_call_time
-
-    # Second call should skip setting first_call_time
-    await state.is_interesting({"a.txt": b"hello"})
-    second_time = state.first_call_time
-
-    # first_call_time should remain the same
-    assert first_time == second_time
 
 
 async def test_report_error_flaky_test(tmp_path, capsys):
@@ -1680,7 +1605,7 @@ fi
     )
 
     # Set initial_exit_code to 0 (what it would be if initial test passed)
-    # Also set first_call = False to prevent run_for_exit_code from overwriting it
+    # Also set first_call = False to prevent run_for_result from overwriting it
     state.initial_exit_code = 0
     state.first_call = False
 
@@ -1721,7 +1646,7 @@ async def test_report_error_nondeterministic(tmp_path, capsys):
     )
 
     # Set initial_exit_code to non-zero (as if initial test returned non-zero)
-    # Also set first_call = False to prevent run_for_exit_code from overwriting it
+    # Also set first_call = False to prevent run_for_result from overwriting it
     state.initial_exit_code = 1
     state.first_call = False
 
@@ -1820,7 +1745,7 @@ async def test_check_formatter_reformatted_is_interesting(tmp_path):
 async def test_timeout_on_first_call(tmp_path):
     """Test that TimeoutExceededOnInitial is raised when first call exceeds timeout.
 
-    Exercises the timeout check on first call in run_for_exit_code.
+    Exercises the timeout check on first call in run_for_result.
     """
     # Create a script that sleeps longer than the timeout
     script = tmp_path / "test.sh"
@@ -1848,7 +1773,7 @@ async def test_timeout_on_first_call(tmp_path):
 
     # First call should raise TimeoutExceededOnInitial (wrapped in ExceptionGroup by trio)
     with pytest.raises(ExceptionGroup) as exc_info:
-        await state.run_for_exit_code(b"hello")
+        await state.run_for_result(b"hello")
 
     # Find the TimeoutExceededOnInitial in the group
     timeout_exc = None
@@ -1898,7 +1823,7 @@ async def test_process_killed_on_timeout(tmp_path):
 
     # First call should raise TimeoutExceededOnInitial and also kill the process
     with pytest.raises(ExceptionGroup) as exc_info:
-        await state.run_for_exit_code(b"hello")
+        await state.run_for_result(b"hello")
 
     # Find the TimeoutExceededOnInitial in the group
     timeout_exc = None
@@ -1948,14 +1873,14 @@ async def test_directory_cleanup_in_place_mode(tmp_path):
     )
 
     # This should exercise the directory cleanup code
-    exit_code = await state.run_for_exit_code({"a.txt": b"modified"})
+    exit_code = (await state.run_for_result({"a.txt": b"modified"})).exit_code
     assert exit_code == 0
 
 
 # === Debug mode tests ===
 
 
-async def test_run_for_exit_code_debug_mode_timeout_on_first_call(tmp_path):
+async def test_run_for_result_debug_mode_timeout_on_first_call(tmp_path):
     """Test timeout handling in debug mode on first call.
 
     Exercises the timeout check in debug mode.
@@ -1986,7 +1911,7 @@ async def test_run_for_exit_code_debug_mode_timeout_on_first_call(tmp_path):
 
     # First call in debug mode should raise TimeoutExceededOnInitial
     with pytest.raises(TimeoutExceededOnInitial) as exc_info:
-        await state.run_for_exit_code(b"hello", debug=True)
+        await state.run_for_result(b"hello", debug=True)
 
     assert exc_info.value.timeout == 0.1
     assert exc_info.value.runtime >= 0.1
@@ -1994,11 +1919,8 @@ async def test_run_for_exit_code_debug_mode_timeout_on_first_call(tmp_path):
     assert state.first_call is False
 
 
-async def test_run_for_exit_code_debug_mode_dynamic_timeout(tmp_path):
-    """Test dynamic timeout computation in debug mode on first call.
-
-    Exercises the dynamic timeout computation path in debug mode.
-    """
+async def test_run_for_result_debug_mode_dynamic_timeout(tmp_path):
+    """Debug mode does not enforce or adapt timeouts on the first call."""
     script = tmp_path / "test.sh"
     script.write_text("#!/bin/bash\nexit 0")
     script.chmod(0o755)
@@ -2022,23 +1944,18 @@ async def test_run_for_exit_code_debug_mode_dynamic_timeout(tmp_path):
         history_enabled=False,
     )
 
-    # First call in debug mode with None timeout should compute dynamic timeout
+    # The user-specified timeout stays unset; timeouts are chosen by the
+    # adaptive policy, which the debug path does not feed.
     assert state.timeout is None
-    exit_code = await state.run_for_exit_code(b"hello", debug=True)
+    exit_code = (await state.run_for_result(b"hello", debug=True)).exit_code
     assert exit_code == 0
-    # After first call, timeout should be computed
-    assert state.timeout is not None
-    assert state.timeout > 0
+    assert state.timeout is None
     # first_call should be False after this
     assert state.first_call is False
 
 
-async def test_run_for_exit_code_dynamic_timeout_non_debug(tmp_path):
-    """Test dynamic timeout computation in non-debug mode on first call.
-
-    Exercises the dynamic timeout computation path in non-debug mode,
-    which uses run_script_on_file instead of the debug path.
-    """
+async def test_run_for_result_dynamic_timeout_non_debug(tmp_path):
+    """The first call's measured runtime feeds the adaptive timeout policy."""
     script = tmp_path / "test.sh"
     script.write_text("#!/bin/bash\nexit 0")
     script.chmod(0o755)
@@ -2062,20 +1979,20 @@ async def test_run_for_exit_code_dynamic_timeout_non_debug(tmp_path):
         history_enabled=False,
     )
 
-    # First call in non-debug mode with None timeout should compute dynamic timeout
+    # With no user timeout, the first call runs under the calibration
+    # timeout and its runtime is recorded by the adaptive policy.
     assert state.timeout is None
-    exit_code = await state.run_for_exit_code(b"hello", debug=False)
+    exit_code = (await state.run_for_result(b"hello", debug=False)).exit_code
     assert exit_code == 0
-    # After first call, timeout should be computed
-    assert state.timeout is not None
-    assert state.timeout > 0
-    # Verify minimum timeout is respected
-    assert state.timeout >= DYNAMIC_TIMEOUT_MIN
+    assert state.timeout is None
+    # The fast measured runtime pulls the adaptive timeout down from the cap.
+    policy = state.timeout_policy
+    assert MIN_TIMEOUT <= policy.current_timeout() < policy.cap
     # first_call should be False after this
     assert state.first_call is False
 
 
-async def test_run_for_exit_code_debug_mode_captures_stdout(tmp_path):
+async def test_run_for_result_debug_mode_captures_stdout(tmp_path):
     """Test that debug mode captures stdout output.
 
     Exercises the stdout capture in debug mode.
@@ -2104,14 +2021,14 @@ async def test_run_for_exit_code_debug_mode_captures_stdout(tmp_path):
     )
 
     # Run in debug mode
-    exit_code = await state.run_for_exit_code(b"hello", debug=True)
+    exit_code = (await state.run_for_result(b"hello", debug=True)).exit_code
     assert exit_code == 0
 
     # Check that stdout was captured
     assert "hello from stdout" in state._last_debug_output
 
 
-async def test_run_for_exit_code_debug_mode_captures_stderr(tmp_path):
+async def test_run_for_result_debug_mode_captures_stderr(tmp_path):
     """Test that debug mode captures stderr output.
 
     Exercises the stderr capture in debug mode.
@@ -2140,7 +2057,7 @@ async def test_run_for_exit_code_debug_mode_captures_stderr(tmp_path):
     )
 
     # Run in debug mode
-    exit_code = await state.run_for_exit_code(b"hello", debug=True)
+    exit_code = (await state.run_for_result(b"hello", debug=True)).exit_code
     assert exit_code == 0
 
     # Check that stderr was captured
@@ -2190,7 +2107,7 @@ async def test_build_error_message_includes_debug_output(tmp_path):
     # Create an InvalidInitialExample exception
     exc = InvalidInitialExample("Test error")
 
-    # Build the error message (this calls run_for_exit_code with debug=True internally)
+    # Build the error message (this calls run_for_result with debug=True internally)
     error_message = await state.build_error_message(exc)
 
     # The error message should include the captured debug output
@@ -2205,7 +2122,7 @@ async def test_build_error_message_includes_cwd_debug_output(tmp_path):
     counter_file.write_text("0")
 
     # Create a script that:
-    # Call 1: run_for_exit_code with debug=True (returns 1 to trigger first-call failure path)
+    # Call 1: run_for_result with debug=True (returns 1 to trigger first-call failure path)
     # Call 2: run_script_on_file with debug=False from cwd (returns 0 to trigger cwd success path)
     # Call 3: run_script_on_file with debug=True from cwd (produces output for error message)
     script = tmp_path / "test.sh"
@@ -2300,7 +2217,7 @@ async def test_volume_debug_inherits_stderr(tmp_path):
     # Run the script - with volume=debug, stderr should NOT be subprocess.DEVNULL
     # We can verify this by checking the kwargs would have stderr=None
     # The actual stderr output would go to the parent process's stderr
-    exit_code = await state.run_for_exit_code(b"hello")
+    exit_code = (await state.run_for_result(b"hello")).exit_code
     assert exit_code == 0
 
 
@@ -2803,10 +2720,10 @@ async def test_run_script_on_file_handles_output_oserror(tmp_path, monkeypatch):
     monkeypatch.setattr("builtins.open", mock_open)
 
     # Run the script - should complete without raising OSError
-    exit_code = await state.run_script_on_file(
+    run_result = await state.run_script_on_file(
         str(target), debug=False, cwd=str(tmp_path)
     )
-    assert exit_code == 0
+    assert run_result.exit_code == 0
 
     # The OSError was caught, so _last_test_output should be None
     assert state._last_test_output is None
@@ -2985,12 +2902,12 @@ async def test_run_script_discards_output_in_quiet_mode_without_history(tmp_path
     )
 
     # Should succeed and discard output
-    exit_code = await state.run_script_on_file(
+    run_result = await state.run_script_on_file(
         working=str(target),
         cwd=str(tmp_path),
         debug=False,
     )
-    assert exit_code == 0
+    assert run_result.exit_code == 0
 
 
 @pytest.mark.trio
@@ -3022,12 +2939,12 @@ async def test_volume_debug_without_history_or_output_manager(tmp_path):
     # With history disabled and debug mode, stderr should be inherited
     # stdout goes to DEVNULL, stderr inherited
     assert state.output_manager is None
-    exit_code = await state.run_script_on_file(
+    run_result = await state.run_script_on_file(
         working=str(target),
         cwd=str(tmp_path),
         debug=False,
     )
-    assert exit_code == 0
+    assert run_result.exit_code == 0
 
 
 @pytest.mark.trio
@@ -3934,7 +3851,7 @@ def working_file_leftovers(directory, filename="reduced.cpp"):
 
 def test_in_place_run_cleans_up_its_working_file(tmp_path):
     state = make_in_place_state(tmp_path)
-    trio.run(state.run_for_exit_code, b"aaa")
+    trio.run(state.run_for_result, b"aaa")
     assert working_file_leftovers(tmp_path) == []
 
 
@@ -3954,7 +3871,7 @@ def test_in_place_working_file_cleanup_survives_cwd_change(tmp_path, monkeypatch
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(state, "run_script_on_file", run_then_chdir)
-    trio.run(state.run_for_exit_code, b"aaa")
+    trio.run(state.run_for_result, b"aaa")
     assert working_file_leftovers(tmp_path) == []
 
 
@@ -4004,3 +3921,159 @@ def test_sweep_tolerates_unlink_failure(tmp_path, monkeypatch):
     monkeypatch.setattr(os, "unlink", boom)
     # Must swallow the error rather than propagating it.
     state.sweep_stale_working_files()
+
+
+# === adaptive timeout integration tests ===
+
+
+def make_adaptive_state(
+    tmp_path,
+    script_body,
+    *,
+    timeout=5.0,
+    min_timeout=0.1,
+    initial=b"hello world",
+):
+    script = tmp_path / "adaptive_test.sh"
+    script.write_text(script_body)
+    script.chmod(0o755)
+
+    target = tmp_path / "adaptive_target.txt"
+    target.write_bytes(initial)
+
+    return ShrinkRayStateSingleFile(
+        input_type=InputType.all,
+        in_place=False,
+        test=[str(script)],
+        filename=str(target),
+        timeout=timeout,
+        base="adaptive_target.txt",
+        parallelism=1,
+        initial=initial,
+        formatter="none",
+        trivial_is_error=True,
+        seed=0,
+        volume=Volume.quiet,
+        history_enabled=False,
+        timeout_policy=AdaptiveTimeoutPolicy(
+            user_timeout=timeout, min_timeout=min_timeout
+        ),
+    )
+
+
+def test_state_creates_timeout_policy_from_user_timeout(simple_state):
+    assert simple_state.timeout_policy.cap == simple_state.timeout
+
+
+async def test_fast_completions_pull_timeout_down(tmp_path):
+    state = make_adaptive_state(tmp_path, "#!/bin/bash\nexit 0", min_timeout=0.2)
+    result = await state.run_for_result(b"hello")
+    assert result.exit_code == 0
+    assert not result.timed_out
+    assert result.timeout_used is None
+    # The fast run pulls the adaptive timeout down well below the cap
+    # (how far depends on the measured runtime).
+    policy = state.timeout_policy
+    assert 0.2 <= policy.current_timeout() < policy.cap
+
+
+async def test_timed_out_run_is_recorded_in_policy(tmp_path):
+    state = make_adaptive_state(tmp_path, "#!/bin/bash\nsleep 5", min_timeout=0.1)
+    policy = state.timeout_policy
+    # Skip first-call calibration and adapt the timeout down so the test
+    # runs quickly.
+    state.first_call = False
+    policy.record_completion(0.02, interesting=True)
+    expected_timeout = policy.current_timeout()
+    assert expected_timeout < 1.0
+
+    result = await state.run_for_result(b"hello")
+    assert result.timed_out
+    assert result.exit_code != 0
+    assert result.timeout_used == pytest.approx(expected_timeout)
+    assert policy.recent_timeout_rate == pytest.approx(0.5)
+
+
+async def test_timed_out_results_are_conditionally_cached(tmp_path):
+    state = make_adaptive_state(tmp_path, "#!/bin/bash\nsleep 5", min_timeout=0.1)
+    policy = state.timeout_policy
+    state.first_call = False
+    policy.record_completion(0.02, interesting=True)
+
+    outcome = await state.check_interesting(b"hello")
+    assert not outcome.interesting
+    assert outcome.cache_valid is not None
+    assert outcome.cache_valid()
+    # Raising the timeout invalidates the cached result.
+    assert policy.attempt_unstick()
+    assert not outcome.cache_valid()
+
+
+async def test_completed_uninteresting_results_cached_unconditionally(tmp_path):
+    state = make_adaptive_state(tmp_path, "#!/bin/bash\nexit 1")
+    outcome = await state.check_interesting(b"hello")
+    assert not outcome.interesting
+    assert outcome.cache_valid is None
+
+
+async def test_interesting_results_cached_unconditionally(tmp_path):
+    state = make_adaptive_state(tmp_path, "#!/bin/bash\nexit 0")
+    outcome = await state.check_interesting(b"hello")
+    assert outcome.interesting
+    assert outcome.cache_valid is None
+
+
+async def test_problem_unstick_raises_policy_timeout(tmp_path):
+    state = make_adaptive_state(tmp_path, "#!/bin/bash\nexit 0", min_timeout=0.1)
+    policy = state.timeout_policy
+    state.first_call = False
+    policy.record_completion(0.02, interesting=True)
+    policy.record_timeout(policy.current_timeout())
+    before = policy.current_timeout()
+
+    problem = state.problem
+    assert await problem.attempt_unstick()
+    assert policy.current_timeout() == 2 * before
+
+    # Repeated unsticking climbs to the cap, then gives up and reverts.
+    while await problem.attempt_unstick():
+        assert policy.current_timeout() <= policy.cap
+    assert policy.current_timeout() == before
+
+
+async def test_reduction_notes_progress_to_policy(tmp_path):
+    state = make_adaptive_state(tmp_path, "#!/bin/bash\nexit 0")
+    problem = state.problem
+    with patch.object(
+        state.timeout_policy, "note_reduction", wraps=state.timeout_policy.note_reduction
+    ) as note:
+        assert await problem.is_interesting(b"hello")
+        note.assert_called_once()
+
+
+def test_reset_for_restart_resets_timeout_policy(tmp_path):
+    state = make_adaptive_state(tmp_path, "#!/bin/bash\nexit 0")
+    policy = state.timeout_policy
+    policy.record_completion(0.02, interesting=True)
+    assert policy.current_timeout() < policy.cap
+    state.reset_for_restart(b"new", set())
+    assert policy.current_timeout() == policy.cap
+
+
+@pytest.mark.slow
+async def test_adaptive_timeout_unlocks_slow_reduction(tmp_path):
+    """End-to-end: a reduction whose interesting form is much slower than
+    the adapted timeout is still found, because the reducer raises the
+    timeout before giving up."""
+    script_body = """#!/bin/bash
+content=$(cat "$1")
+if [ "$content" = "hello world" ]; then exit 0; fi
+if [ "$content" = "hello" ]; then sleep 0.4; exit 0; fi
+exit 1
+"""
+    state = make_adaptive_state(
+        tmp_path, script_body, timeout=10.0, min_timeout=0.15
+    )
+    await state.problem.setup()
+    await state.reducer.run()
+    assert state.problem.current_test_case == b"hello"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -3962,7 +3962,11 @@ def test_state_creates_timeout_policy_from_user_timeout(simple_state):
 
 
 async def test_fast_completions_pull_timeout_down(tmp_path):
-    state = make_adaptive_state(tmp_path, "#!/bin/bash\nexit 0", min_timeout=0.2)
+    # A generous cap so that even a heavily loaded machine (slow script
+    # startup inflates the measured runtime) stays well below it.
+    state = make_adaptive_state(
+        tmp_path, "#!/bin/bash\nexit 0", timeout=60.0, min_timeout=0.2
+    )
     result = await state.run_for_result(b"hello")
     assert result.exit_code == 0
     assert not result.timed_out

--- a/tests/test_subprocess_protocol.py
+++ b/tests/test_subprocess_protocol.py
@@ -234,3 +234,27 @@ def test_serialize_invalid_type():
 def test_serialize_dict_raises():
     with pytest.raises(TypeError):
         serialize({"id": "123"})  # type: ignore
+
+
+def test_progress_update_timeout_fields_roundtrip():
+    original = ProgressUpdate(
+        status="Working",
+        size=500,
+        original_size=1000,
+        calls=25,
+        reductions=5,
+        current_timeout=2.5,
+        timeout_rate=0.125,
+    )
+    deserialized = deserialize(serialize(original))
+    assert isinstance(deserialized, ProgressUpdate)
+    assert deserialized.current_timeout == 2.5
+    assert deserialized.timeout_rate == 0.125
+
+
+def test_progress_update_timeout_fields_default():
+    line = '{"type":"progress","data":{"status":"test","size":100,"original_size":200,"calls":5,"reductions":2}}'
+    result = deserialize(line)
+    assert isinstance(result, ProgressUpdate)
+    assert result.current_timeout is None
+    assert result.timeout_rate == 0.0

--- a/tests/test_subprocess_worker.py
+++ b/tests/test_subprocess_worker.py
@@ -1680,6 +1680,7 @@ async def test_build_progress_update_with_reducer_none():
 
     # Set up state for parallel workers calculation
     worker.state = Mock()
+    worker.state.timeout_policy = AdaptiveTimeoutPolicy(user_timeout=math.inf)
     worker.state.parallel_tasks_running = 2
     worker.state.output_manager = None  # No test output capture
 
@@ -1721,6 +1722,7 @@ async def test_build_progress_update_with_reducer_pass_stats_none():
 
     # Set up state
     worker.state = Mock()
+    worker.state.timeout_policy = AdaptiveTimeoutPolicy(user_timeout=math.inf)
     worker.state.parallel_tasks_running = 2
     worker.state.output_manager = None  # No test output capture
 
@@ -1759,6 +1761,7 @@ async def test_build_progress_update_with_reducer_no_disabled_passes_attr():
 
     # Set up state
     worker.state = Mock()
+    worker.state.timeout_policy = AdaptiveTimeoutPolicy(user_timeout=math.inf)
     worker.state.parallel_tasks_running = 2
     worker.state.output_manager = None  # No test output capture
 
@@ -1791,6 +1794,7 @@ async def test_build_progress_update_periodic_size_history():
     worker.problem.current_test_case = b"test content"
 
     worker.state = Mock()
+    worker.state.timeout_policy = AdaptiveTimeoutPolicy(user_timeout=math.inf)
     worker.state.parallel_tasks_running = 2
     worker.state.output_manager = None
 
@@ -3088,6 +3092,7 @@ async def test_build_progress_update_includes_adaptive_timeout():
     worker.problem.current_test_case = b"test content"
 
     worker.state = Mock()
+    worker.state.timeout_policy = AdaptiveTimeoutPolicy(user_timeout=math.inf)
     worker.state.parallel_tasks_running = 2
     worker.state.output_manager = None
     worker.state.history_manager = None
@@ -3101,7 +3106,7 @@ async def test_build_progress_update_includes_adaptive_timeout():
 
 
 @pytest.mark.trio
-async def test_build_progress_update_timeout_none_when_disabled():
+async def test_build_progress_update_timeout_none_when_unbounded_with_no_data():
     worker = ReducerWorker()
     worker.reducer = None
     worker.problem = Mock()
@@ -3117,6 +3122,7 @@ async def test_build_progress_update_timeout_none_when_disabled():
     worker.problem.current_test_case = b"test content"
 
     worker.state = Mock()
+    worker.state.timeout_policy = AdaptiveTimeoutPolicy(user_timeout=math.inf)
     worker.state.parallel_tasks_running = 2
     worker.state.output_manager = None
     worker.state.history_manager = None

--- a/tests/test_subprocess_worker.py
+++ b/tests/test_subprocess_worker.py
@@ -2,6 +2,7 @@
 
 import io
 import json
+import math
 import os
 import runpy
 import signal
@@ -14,6 +15,7 @@ import trio
 import trio.testing
 
 import shrinkray.subprocess.worker
+from shrinkray.adaptive_timeout import AdaptiveTimeoutPolicy
 from shrinkray.problem import InvalidInitialExample
 from shrinkray.state import ShrinkRayDirectoryState, ShrinkRayStateSingleFile
 from shrinkray.subprocess.protocol import (
@@ -471,6 +473,7 @@ async def test_worker_emit_progress_updates_loop():
     mock_state.parallel_tasks_running = 2
     mock_state.output_manager = None  # No test output capture in this mock
     mock_state.history_manager = None  # No history in this mock
+    mock_state.timeout_policy = AdaptiveTimeoutPolicy(user_timeout=math.inf)
     worker.state = mock_state
 
     # Run for a short time then stop
@@ -720,9 +723,12 @@ async def test_worker_emit_progress_updates_no_parallel_attr():
     worker.reducer = mock_reducer
 
     # State without parallel_tasks_running attribute
-    mock_state = MagicMock(spec=["output_manager", "history_manager"])
+    mock_state = MagicMock(
+        spec=["output_manager", "history_manager", "timeout_policy"]
+    )
     mock_state.output_manager = None  # No test output capture
     mock_state.history_manager = None  # No history
+    mock_state.timeout_policy = AdaptiveTimeoutPolicy(user_timeout=math.inf)
     worker.state = mock_state
 
     # Run for a short time then stop
@@ -3065,3 +3071,60 @@ async def test_restart_integration_status_updates(tmp_path):
     finally:
         os.chdir(old_cwd)
         await input_stream.aclose()
+
+
+@pytest.mark.trio
+async def test_build_progress_update_includes_adaptive_timeout():
+    worker = ReducerWorker()
+    worker.reducer = None
+    worker.problem = Mock()
+    worker.problem.stats = Mock()
+    worker.problem.stats.current_test_case_size = 100
+    worker.problem.stats.initial_test_case_size = 1000
+    worker.problem.stats.calls = 10
+    worker.problem.stats.reductions = 2
+    worker.problem.stats.interesting_calls = 5
+    worker.problem.stats.wasted_interesting_calls = 1
+    worker.problem.stats.start_time = time.time()
+    worker.problem.stats.time_since_last_reduction = Mock(return_value=0.5)
+    worker.problem.current_test_case = b"test content"
+
+    worker.state = Mock()
+    worker.state.parallel_tasks_running = 2
+    worker.state.output_manager = None
+    worker.state.history_manager = None
+    worker.state.timeout_policy = AdaptiveTimeoutPolicy(user_timeout=50.0)
+    worker.state.timeout_policy.record_completion(0.1, interesting=True)
+
+    update = await worker._build_progress_update()
+    assert update is not None
+    assert update.current_timeout == pytest.approx(1.0)  # 10x the runtime
+    assert update.timeout_rate == 0.0
+
+
+@pytest.mark.trio
+async def test_build_progress_update_timeout_none_when_disabled():
+    worker = ReducerWorker()
+    worker.reducer = None
+    worker.problem = Mock()
+    worker.problem.stats = Mock()
+    worker.problem.stats.current_test_case_size = 100
+    worker.problem.stats.initial_test_case_size = 1000
+    worker.problem.stats.calls = 10
+    worker.problem.stats.reductions = 2
+    worker.problem.stats.interesting_calls = 5
+    worker.problem.stats.wasted_interesting_calls = 1
+    worker.problem.stats.start_time = time.time()
+    worker.problem.stats.time_since_last_reduction = Mock(return_value=0.5)
+    worker.problem.current_test_case = b"test content"
+
+    worker.state = Mock()
+    worker.state.parallel_tasks_running = 2
+    worker.state.output_manager = None
+    worker.state.history_manager = None
+    worker.state.timeout_policy = AdaptiveTimeoutPolicy(user_timeout=math.inf)
+
+    update = await worker._build_progress_update()
+    assert update is not None
+    assert update.current_timeout is None
+    assert update.timeout_rate == 0.0

--- a/tests/test_subprocess_worker.py
+++ b/tests/test_subprocess_worker.py
@@ -723,9 +723,7 @@ async def test_worker_emit_progress_updates_no_parallel_attr():
     worker.reducer = mock_reducer
 
     # State without parallel_tasks_running attribute
-    mock_state = MagicMock(
-        spec=["output_manager", "history_manager", "timeout_policy"]
-    )
+    mock_state = MagicMock(spec=["output_manager", "history_manager", "timeout_policy"])
     mock_state.output_manager = None  # No test output capture
     mock_state.history_manager = None  # No history
     mock_state.timeout_policy = AdaptiveTimeoutPolicy(user_timeout=math.inf)

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -7429,3 +7429,35 @@ def test_history_modal_highlighted_skipped_during_refresh(tmp_path):
     modal.set_timer.assert_not_called()
     # Selection path should remain unchanged
     assert modal._selected_reductions_path == str(entry_dir)
+
+
+def test_stats_display_shows_adaptive_timeout():
+    widget = StatsDisplay()
+    update = ProgressUpdate(
+        status="Testing",
+        size=500,
+        original_size=1000,
+        calls=20,
+        reductions=8,
+        runtime=5.0,
+        current_timeout=2.5,
+        timeout_rate=0.25,
+    )
+    widget.update_stats(update)
+    rendered = widget.render()
+    assert "Test timeout: 2.5s" in rendered
+    assert "25%" in rendered
+
+
+def test_stats_display_hides_timeout_when_unknown():
+    widget = StatsDisplay()
+    update = ProgressUpdate(
+        status="Testing",
+        size=500,
+        original_size=1000,
+        calls=20,
+        reductions=8,
+        runtime=5.0,
+    )
+    widget.update_stats(update)
+    assert "Test timeout" not in widget.render()


### PR DESCRIPTION
<details>
<summary>AI-generated description</summary>

This replaces the fixed test timeout (10x the first run's time) with an adaptive one, chosen continuously from recent measured runtimes: a generous multiple of a high quantile of recent completions, with a floor based on the slowest recent *interesting* runs so we don't clip the runs that matter. As tests get faster over the course of a reduction the timeout follows them down, and the generous multipliers keep it robust to variance under parallel load.

The motivating problem is reductions that make the test *slower* (e.g. a loop that now takes many more iterations, or crashes that sit right next to very expensive inputs, as in the splr evaluation): with a fixed timeout these candidates just get killed and the reduction silently misses them. Now, when reduction stalls while a meaningful fraction of runs are timing out — and again whenever the reducer would otherwise finish with timeouts on record — the timeout is raised step by step (up to `--timeout`, or 5 minutes if unset) to see whether slower runs unlock progress, and dropped back down if they don't. Cached "uninteresting" results from timed-out runs are only trusted while the timeout hasn't been raised past what they ran under, so those candidates genuinely get retried.

`--timeout` keeps its role as a hard upper bound (and `--timeout <= 0` still disables timeouts entirely); the TUI now shows the current timeout and the recent timeout rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>