### PR TITLE
Adaptive pass scheduling driven by a call-count benchmark

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,12 @@ If you encounter a case where suppression seems genuinely necessary and principl
 - Use the `/checkpoint` skill to ensure consistent quality at each commit
 - **Always use `git add` with specific file paths** - Never use `git add -A`, `git add .`, or `git add <directory>`. Always list the specific files you intend to stage. This prevents accidentally committing unrelated files (test scripts, debug files, etc.).
 
+### Pull Requests
+
+- **Wrap any AI-generated PR description in a `<details></details>` block** (with a
+  short `<summary>` line), so the PR page stays compact and it's clear which prose
+  is machine-written.
+
 ### No Backward Compatibility
 
 Shrink Ray is a standalone application, not a library. Do not add backward compatibility shims, re-exports, or compatibility layers when refactoring. When moving code between modules, update all imports directly rather than re-exporting from the old location.
@@ -146,7 +152,10 @@ Shrink Ray is a multiformat test-case reducer built on Trio for async/parallelis
 1. **initial_cuts**: Fast high-value passes (comments, hollow, large blocks) with timeout-based cancellation
 2. **great_passes**: Core loop (line and semicolon-split deletion, hollow, lift_braces, debracket) - loops until no progress
 3. **ok_passes**: Run when great_passes stop making progress
-4. **last_ditch_passes**: Expensive or low-yield passes (byte lowering, substitutions)
+4. **last_ditch_passes**: Expensive or low-yield passes (token block deletion, substitutions)
+5. **polish_passes**: Very expensive, mostly-normalising passes (short_deletions, byte lowering), run only after everything else converges
+
+Pass scheduling is adaptive (see `notes/reduction-passes.md`): fruitless completed runs are fingerprinted and skipped until the test case changes, passes with a fruitless record run under a probation call budget, and budget-aborted passes are re-run in full before termination so final results are unaffected. Changes to scheduling should be measured with `evaluation/benchmark.py` (judge by interestingness calls, never wall-clock).
 
 ### Parallelism Model
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+- Reduction passes are now scheduled adaptively: expensive passes that
+  rarely find anything run only after everything else has converged, and a
+  pass that recently made no progress is given only a short trial before
+  Shrink Ray moves on to more promising work (it is still re-run in full
+  before finishing, so final results are unaffected). Reductions make
+  progress sooner and typically need fewer runs of the interestingness test.

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -17,6 +17,7 @@ shrink ray dispatches for that format.
 ```
 evaluation/
 ├── run.py        # reduce entries with shrink ray, write result.json
+├── watch.py      # run one entry interactively in the TUI (records nothing)
 ├── report.py     # regenerate the tables in RESULTS.md
 ├── benchmark.py  # measure reducer efficiency (interestingness calls) against cheap in-process oracles
 ├── benchmark_baseline.json  # committed benchmark metrics for main (compare with benchmark.py --baseline)
@@ -123,6 +124,18 @@ python3 evaluation/run.py mypy-0.942-match-union-tuple-crash
 
 # Regenerate the tables in RESULTS.md
 python3 evaluation/report.py
+```
+
+To *watch* a reduction in shrink ray's normal interactive TUI, use
+`watch.py`. It sets up the entry's oracle exactly as run.py would, but
+always restarts from the original input, runs attached to your terminal,
+and records nothing (it reduces `<entry>/work/watch<ext>`, leaving
+run.py's resumable state and the committed results untouched). Unknown
+arguments are forwarded to shrinkray:
+
+```bash
+python3 evaluation/watch.py ruff-0.0.277-isort-skip-block-panic
+python3 evaluation/watch.py pylint-2.17.4-duplicate-bases-mro-crash --parallelism 4
 ```
 
 The C/C++ entries use amd64-only compiler images which run under

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -19,6 +19,7 @@ evaluation/
 ├── run.py        # reduce entries with shrink ray, write result.json
 ├── report.py     # regenerate the tables in RESULTS.md
 ├── benchmark.py  # measure reducer efficiency (interestingness calls) against cheap in-process oracles
+├── benchmark_baseline.json  # committed benchmark metrics for main (compare with benchmark.py --baseline)
 ├── RESULTS.md    # generated tables + hand-written analysis
 ├── corpus/<id>/  # one directory per bug
 ├── sortkey/      # sort-key tuning corpus (see sortkey/README.md)

--- a/evaluation/benchmark.py
+++ b/evaluation/benchmark.py
@@ -7,19 +7,53 @@ reducer's own behaviour (pass ordering, stopping, tail churn) rather than
 how slow a real oracle is. Wall-clock cost of a real reduction is roughly
 `calls * oracle_time`, so fewer calls helps every entry in the corpus.
 
-Runs at parallelism 1 for reproducibility.
+Problems come in two flavours:
 
-    python3 evaluation/benchmark.py            # run all, print a table
-    python3 evaluation/benchmark.py <name> ... # run selected problems
+- synthetic: constructed inputs isolating one reducer behaviour
+  (bulk deletion, rigid-structure tail churn, stopping overhead).
+- corpus-derived: `original.*` files from `evaluation/corpus/` with a cheap
+  predicate approximating the real bug's requirements (required tokens,
+  syntactic validity, structural properties). These give realistic
+  reduction *trajectories* without a slow oracle.
+
+Metrics per problem:
+
+- calls: total interestingness-test calls (the primary cost metric).
+- final size: quality of the result (guards against "fast but worse").
+- c90 / c99: calls needed to achieve 90% / 99% of the total size
+  reduction the run eventually achieved (how front-loaded progress is).
+- tail: calls after the last successful reduction (pure stopping cost).
+
+Runs at parallelism 1, which is deterministic (WorkContext seeds its own
+Random(0)), so results are exactly reproducible run to run.
+
+    python3 evaluation/benchmark.py                 # run all, print a table
+    python3 evaluation/benchmark.py NAME ...        # run selected problems
+    python3 evaluation/benchmark.py --json out.json # also dump metrics
+    python3 evaluation/benchmark.py --baseline B    # compare against a dump
+    python3 evaluation/benchmark.py --passes        # per-pass stats tables
 """
 
+import argparse
+import ast
+import json as json_module
 import sys
+import time
+import warnings
+from pathlib import Path
+
 import trio
 
 from shrinkray.problem import BasicReductionProblem
 from shrinkray.reducer import ShrinkRay
 from shrinkray.state import sort_key_for_initial
 from shrinkray.work import WorkContext
+
+
+CORPUS = Path(__file__).resolve().parent / "corpus"
+
+
+# --- predicate helpers ------------------------------------------------------
 
 
 def bracket_depth(data: bytes) -> int:
@@ -37,26 +71,61 @@ def bracket_depth(data: bytes) -> int:
     return worst if depth == 0 else -1
 
 
-def run_problem(initial: bytes, is_interesting) -> tuple[bytes, int]:
-    async def acond(x: bytes) -> bool:
-        await trio.lowlevel.checkpoint()
-        return is_interesting(x)
-
-    async def go() -> tuple[bytes, int]:
-        problem: BasicReductionProblem[bytes] = BasicReductionProblem(
-            initial=initial,
-            is_interesting=acond,
-            work=WorkContext(parallelism=1),
-            sort_key=sort_key_for_initial(initial),
-        )
-        reducer = ShrinkRay(target=problem)
-        await reducer.run()
-        return problem.current_test_case, problem.stats.calls
-
-    return trio.run(go)
+def compiles_as_python(data: bytes) -> bool:
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            compile(data, "<benchmark>", "exec")
+    except Exception:
+        return False
+    return True
 
 
-# --- problem definitions: (name, initial, predicate) -----------------------
+def json_depth(data: bytes) -> int:
+    """Max nesting depth of a valid JSON document, else -1."""
+    try:
+        doc = json_module.loads(data)
+    except Exception:
+        return -1
+    depth = 0
+    stack = [(doc, 1)]
+    while stack:
+        value, d = stack.pop()
+        depth = max(depth, d)
+        if isinstance(value, dict):
+            stack.extend((child, d + 1) for child in value.values())
+        elif isinstance(value, list):
+            stack.extend((child, d + 1) for child in value)
+    return depth
+
+
+def has_dup_bases_and_metaclass(data: bytes) -> bool:
+    """Some class has syntactically duplicate bases, and some class uses a
+    metaclass keyword. Approximates the pylint/astroid DuplicateBasesError
+    corpus entry's requirements."""
+    try:
+        tree = ast.parse(data)
+    except Exception:
+        return False
+    dup = meta = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            dumped = [ast.dump(base) for base in node.bases]
+            if len(dumped) != len(set(dumped)):
+                dup = True
+            if any(kw.arg == "metaclass" for kw in node.keywords):
+                meta = True
+    return dup and meta
+
+
+def contains_all(*tokens: bytes):
+    def predicate(data: bytes) -> bool:
+        return all(t in data for t in tokens)
+
+    return predicate
+
+
+# --- synthetic problem inputs -----------------------------------------------
 
 
 def _scaffolded_deep_parens() -> bytes:
@@ -92,40 +161,295 @@ def _already_minimal() -> bytes:
     return b"x=RARE_MARKER_ALPHA+RARE_MARKER_BETA\n"
 
 
-PROBLEMS: dict[str, tuple[bytes, object]] = {
-    # Rigid deep structure: reduces to minimal parens at depth >= 400, then
-    # the reducer keeps trying (and failing) to go smaller -> tail churn.
-    "deep_parens": (
-        _scaffolded_deep_parens(),
-        lambda x: bracket_depth(x) >= 400,
-    ),
-    # Bulk deletion of a large file down to three scattered required markers.
-    "keep_markers": (
-        _big_file_with_markers(),
-        lambda x: b"RARE_MARKER_ALPHA" in x
-        and b"RARE_MARKER_BETA" in x
-        and b"RARE_MARKER_GAMMA" in x,
-    ),
-    # Already minimal: pure measure of the stopping / no-progress overhead.
-    "already_minimal": (
-        _already_minimal(),
-        lambda x: b"RARE_MARKER_ALPHA" in x and b"RARE_MARKER_BETA" in x,
-    ),
-}
+def _python_module_with_sentinel() -> bytes:
+    """A plausible generated module where candidates must stay valid Python.
+
+    Exercises the high-rejection regime typical of real reductions of
+    strict-syntax languages: most byte-level candidates fail to compile.
+    """
+    parts = [
+        b'"""Utilities for the frobnication service."""\n',
+        b"import collections\n",
+        b"import functools\n\n",
+    ]
+    for i in range(60):
+        parts.append(
+            (
+                f"class Handler{i}:\n"
+                f"    priority = {i}\n"
+                f"    def process(self, item):\n"
+                f"        queue = collections.deque(maxlen={i + 1})\n"
+                f"        queue.append(item)\n"
+                f"        return sorted(queue)\n\n"
+            ).encode()
+        )
+        if i == 30:
+            parts.append(
+                b"def sentinel():\n    SENTINEL_KEEP = 1\n    return SENTINEL_KEEP\n\n"
+            )
+    return b"".join(parts)
+
+
+# --- problem table ----------------------------------------------------------
+
+
+class Problem:
+    def __init__(self, initial: bytes, predicate, *, cpp: bool = False):
+        self.initial = initial
+        self.predicate = predicate
+        self.cpp = cpp
+
+
+def _corpus_file(entry: str, filename: str) -> bytes:
+    return (CORPUS / entry / filename).read_bytes()
+
+
+def build_problems() -> dict[str, Problem]:
+    problems = {
+        # Rigid deep structure: reduces to minimal parens at depth >= 400,
+        # then the reducer keeps trying (and failing) to go smaller.
+        "deep_parens": Problem(
+            _scaffolded_deep_parens(),
+            lambda x: bracket_depth(x) >= 400,
+        ),
+        # Bulk deletion of a large file down to three scattered markers.
+        "keep_markers": Problem(
+            _big_file_with_markers(),
+            contains_all(
+                b"RARE_MARKER_ALPHA", b"RARE_MARKER_BETA", b"RARE_MARKER_GAMMA"
+            ),
+        ),
+        # Already minimal: pure measure of stopping / no-progress overhead.
+        "already_minimal": Problem(
+            _already_minimal(),
+            contains_all(b"RARE_MARKER_ALPHA", b"RARE_MARKER_BETA"),
+        ),
+        # Valid-Python-required marker hunt: most candidates get rejected.
+        "python_syntax": Problem(
+            _python_module_with_sentinel(),
+            lambda x: b"SENTINEL_KEEP" in x and compiles_as_python(x),
+        ),
+        # Corpus-derived problems. Predicates approximate each entry's real
+        # bug requirements; see evaluation/corpus/<id>/meta.json.
+        "corpus_mypy": Problem(
+            _corpus_file("mypy-0.942-match-union-tuple-crash", "original.py"),
+            lambda x: (
+                compiles_as_python(x)
+                and contains_all(b"match ", b"case ", b"Union[", b"tuple[")(x)
+            ),
+        ),
+        "corpus_pylint": Problem(
+            _corpus_file("pylint-2.17.4-duplicate-bases-mro-crash", "original.py"),
+            has_dup_bases_and_metaclass,
+        ),
+        "corpus_ujson": Problem(
+            _corpus_file("ujson-510-indent-buffer-overflow", "original.json"),
+            lambda x: json_depth(x) >= 20,
+        ),
+        "corpus_udlit_cpp": Problem(
+            _corpus_file("gcc49-udlit-char-pack-template", "original.cpp"),
+            contains_all(b'operator""', b"decltype(", b"..."),
+            cpp=True,
+        ),
+        "corpus_minisat": Problem(
+            _corpus_file("minisat-dimacs-int-overflow", "original.cnf"),
+            contains_all(b"2147483648"),
+        ),
+    }
+    return problems
+
+
+# --- running and metrics ----------------------------------------------------
+
+
+def run_problem(name: str, problem: Problem) -> dict:
+    events: list[dict] = []
+
+    async def acond(x: bytes) -> bool:
+        await trio.lowlevel.checkpoint()
+        return problem.predicate(x)
+
+    async def go() -> tuple[bytes, object, object]:
+        reduction_problem: BasicReductionProblem[bytes] = BasicReductionProblem(
+            initial=problem.initial,
+            is_interesting=acond,
+            work=WorkContext(parallelism=1),
+            sort_key=sort_key_for_initial(problem.initial),
+        )
+
+        async def record(test_case: bytes) -> None:
+            stats = reduction_problem.current_pass_stats
+            events.append(
+                {
+                    "calls": reduction_problem.stats.calls,
+                    "size": len(test_case),
+                    "pass": stats.pass_name if stats is not None else None,
+                }
+            )
+
+        reduction_problem.on_reduce(record)
+        reducer = ShrinkRay(target=reduction_problem, enable_cpp_passes=problem.cpp)
+        await reducer.run()
+        return reduction_problem.current_test_case, reduction_problem, reducer
+
+    start = time.monotonic()
+    result, reduction_problem, reducer = trio.run(go)
+    seconds = time.monotonic() - start
+
+    initial_size = len(problem.initial)
+    final_size = len(result)
+    calls = reduction_problem.stats.calls
+
+    def calls_to_fraction(fraction: float) -> int:
+        if initial_size == final_size:
+            return 0
+        threshold = initial_size - fraction * (initial_size - final_size)
+        for event in events:
+            if event["size"] <= threshold:
+                return event["calls"]
+        return calls
+
+    tail_calls = calls - events[-1]["calls"] if events else calls
+
+    pass_stats = [
+        {
+            "pass": s.pass_name,
+            "runs": s.run_count,
+            "calls": s.test_evaluations,
+            "reductions": s.successful_reductions,
+            "bytes_deleted": s.bytes_deleted,
+        }
+        for s in reducer.pass_stats.get_stats_in_order()
+    ]
+
+    return {
+        "name": name,
+        "initial_size": initial_size,
+        "final_size": final_size,
+        "calls": calls,
+        "c90": calls_to_fraction(0.90),
+        "c99": calls_to_fraction(0.99),
+        "tail": tail_calls,
+        "reductions": len(events),
+        "seconds": round(seconds, 2),
+        "pass_stats": pass_stats,
+        "events": events,
+    }
+
+
+# --- output -----------------------------------------------------------------
+
+TABLE_COLUMNS = [
+    ("problem", "name", "<24"),
+    ("calls", "calls", ">8"),
+    ("final", "final_size", ">7"),
+    ("c90", "c90", ">8"),
+    ("c99", "c99", ">8"),
+    ("tail", "tail", ">7"),
+    ("secs", "seconds", ">7"),
+]
+
+
+def print_table(results: list[dict]) -> None:
+    header = " ".join(f"{title:{fmt}}" for title, _, fmt in TABLE_COLUMNS)
+    print(header)
+    print("-" * len(header))
+    for r in results:
+        print(" ".join(f"{r[key]:{fmt}}" for _, key, fmt in TABLE_COLUMNS))
+    total_calls = sum(r["calls"] for r in results)
+    print("-" * len(header))
+    print(f"{'TOTAL':<24} {total_calls:>8}")
+
+
+def print_pass_stats(results: list[dict]) -> None:
+    for r in results:
+        print()
+        print(f"=== {r['name']} (calls={r['calls']}) ===")
+        print(f"{'pass':<40} {'runs':>5} {'calls':>8} {'reds':>6} {'deleted':>9}")
+        for s in sorted(r["pass_stats"], key=lambda s: -s["calls"]):
+            if s["calls"] == 0 and s["reductions"] == 0:
+                continue
+            print(
+                f"{s['pass']:<40} {s['runs']:>5} {s['calls']:>8} "
+                f"{s['reductions']:>6} {s['bytes_deleted']:>9}"
+            )
+
+
+def print_comparison(baseline: dict, results: list[dict]) -> None:
+    by_name = {r["name"]: r for r in baseline["results"]}
+    print(f"{'problem':<24} {'calls':>16} {'Δ%':>7} {'final':>12} {'c99':>16}")
+    print("-" * 80)
+    total_old = total_new = 0
+    for r in results:
+        old = by_name.get(r["name"])
+        if old is None:
+            print(f"{r['name']:<24} {'(new)':>16}")
+            continue
+        total_old += old["calls"]
+        total_new += r["calls"]
+        delta = (
+            (r["calls"] - old["calls"]) / old["calls"] * 100 if old["calls"] else 0.0
+        )
+        print(
+            f"{r['name']:<24} "
+            f"{old['calls']:>7} → {r['calls']:>6} {delta:>+6.1f}% "
+            f"{old['final_size']:>5} → {r['final_size']:>4} "
+            f"{old['c99']:>7} → {r['c99']:>6}"
+        )
+    if total_old:
+        overall = (total_new - total_old) / total_old * 100
+        print("-" * 80)
+        print(f"{'TOTAL':<24} {total_old:>7} → {total_new:>6} {overall:>+6.1f}%")
 
 
 def main() -> int:
-    names = sys.argv[1:] or list(PROBLEMS)
-    print(f"{'problem':<18} {'calls':>8} {'final size':>11}")
-    print("-" * 40)
-    total = 0
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("names", nargs="*", help="problems to run (default: all)")
+    parser.add_argument("--json", help="write metrics to this file")
+    parser.add_argument("--baseline", help="compare against a previous --json dump")
+    parser.add_argument(
+        "--passes", action="store_true", help="print per-pass stats tables"
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="include per-reduction event lists in the --json dump",
+    )
+    args = parser.parse_args()
+
+    problems = build_problems()
+    names = args.names or list(problems)
+    unknown = [n for n in names if n not in problems]
+    if unknown:
+        parser.error(
+            f"unknown problems: {', '.join(unknown)}. Available: {', '.join(problems)}"
+        )
+
+    for name, problem in problems.items():
+        if not problem.predicate(problem.initial):
+            raise AssertionError(
+                f"problem {name}: predicate is false on its initial input"
+            )
+
+    results = []
     for name in names:
-        initial, pred = PROBLEMS[name]
-        result, calls = run_problem(initial, pred)
-        total += calls
-        print(f"{name:<18} {calls:>8} {len(result):>11}")
-    print("-" * 40)
-    print(f"{'TOTAL':<18} {total:>8}")
+        results.append(run_problem(name, problems[name]))
+
+    print_table(results)
+    if args.passes:
+        print_pass_stats(results)
+    if args.baseline:
+        print()
+        with open(args.baseline) as f:
+            baseline = json_module.load(f)
+        print_comparison(baseline, results)
+    if args.json:
+        dumped = results
+        if not args.full:
+            dumped = [{k: v for k, v in r.items() if k != "events"} for r in results]
+        with open(args.json, "w") as f:
+            json_module.dump({"results": dumped}, f, indent=2)
+        print(f"\nwrote {args.json}")
     return 0
 
 

--- a/evaluation/benchmark.py
+++ b/evaluation/benchmark.py
@@ -24,8 +24,10 @@ Metrics per problem:
   reduction the run eventually achieved (how front-loaded progress is).
 - tail: calls after the last successful reduction (pure stopping cost).
 
-Runs at parallelism 1, which is deterministic (WorkContext seeds its own
-Random(0)), so results are exactly reproducible run to run.
+Runs at parallelism 1 with a fixed random seed (WorkContext seeds its own
+Random(0)), so call counts are reproducible to within a couple of calls
+run to run; judge changes by call counts, not the informational seconds
+column, which varies with machine load.
 
     python3 evaluation/benchmark.py                 # run all, print a table
     python3 evaluation/benchmark.py NAME ...        # run selected problems

--- a/evaluation/benchmark_baseline.json
+++ b/evaluation/benchmark_baseline.json
@@ -1,0 +1,2137 @@
+{
+  "results": [
+    {
+      "name": "deep_parens",
+      "initial_size": 3794,
+      "final_size": 800,
+      "calls": 14167,
+      "c90": 11267,
+      "c99": 11475,
+      "tail": 2666,
+      "reductions": 1132,
+      "seconds": 5.97,
+      "pass_stats": [
+        {
+          "pass": "cut_comment_like_things",
+          "runs": 3,
+          "calls": 1,
+          "reductions": 1,
+          "bytes_deleted": 27
+        },
+        {
+          "pass": "hollow",
+          "runs": 6,
+          "calls": 1,
+          "reductions": 1,
+          "bytes_deleted": 15
+        },
+        {
+          "pass": "split(b'\\n')/delete_duplicates",
+          "runs": 6,
+          "calls": 1,
+          "reductions": 1,
+          "bytes_deleted": 6
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(10, 100)",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lift_braces",
+          "runs": 6,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "remove_indents",
+          "runs": 8,
+          "calls": 1,
+          "reductions": 1,
+          "bytes_deleted": 16
+        },
+        {
+          "pass": "remove_whitespace",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(1, 10)",
+          "runs": 5,
+          "calls": 19,
+          "reductions": 2,
+          "bytes_deleted": 118
+        },
+        {
+          "pass": "split(b';')/block_deletion(1, 10)",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "debracket",
+          "runs": 5,
+          "calls": 603,
+          "reductions": 200,
+          "bytes_deleted": 400
+        },
+        {
+          "pass": "delete_byte_spans",
+          "runs": 3,
+          "calls": 783,
+          "reductions": 525,
+          "bytes_deleted": 1210
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(11, 20)",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "tokenize/block_deletion(1, 20)",
+          "runs": 2,
+          "calls": 10251,
+          "reductions": 401,
+          "bytes_deleted": 1202
+        },
+        {
+          "pass": "reduce_integer_literals",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_falsey_with_zero",
+          "runs": 2,
+          "calls": 1,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "combine_expressions",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "merge_adjacent_strings",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lexeme_based_deletions",
+          "runs": 2,
+          "calls": 11,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "short_deletions",
+          "runs": 2,
+          "calls": 64,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "normalize_identifiers",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "line_sorter",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(21, 100)",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_space_with_newlines",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_bytes",
+          "runs": 1,
+          "calls": 24,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_individual_bytes",
+          "runs": 1,
+          "calls": 2400,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "simplify_brackets",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "standard_substitutions",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        }
+      ]
+    },
+    {
+      "name": "keep_markers",
+      "initial_size": 174747,
+      "final_size": 50,
+      "calls": 1163,
+      "c90": 74,
+      "c99": 132,
+      "tail": 884,
+      "reductions": 110,
+      "seconds": 10.06,
+      "pass_stats": [
+        {
+          "pass": "cut_comment_like_things",
+          "runs": 3,
+          "calls": 1,
+          "reductions": 1,
+          "bytes_deleted": 20890
+        },
+        {
+          "pass": "hollow",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/delete_duplicates",
+          "runs": 4,
+          "calls": 1,
+          "reductions": 1,
+          "bytes_deleted": 36000
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(10, 100)",
+          "runs": 2,
+          "calls": 183,
+          "reductions": 100,
+          "bytes_deleted": 117781
+        },
+        {
+          "pass": "lift_braces",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "remove_indents",
+          "runs": 6,
+          "calls": 1,
+          "reductions": 1,
+          "bytes_deleted": 8
+        },
+        {
+          "pass": "remove_whitespace",
+          "runs": 4,
+          "calls": 1,
+          "reductions": 1,
+          "bytes_deleted": 4
+        },
+        {
+          "pass": "replace_bodies_with_ellipsis",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "strip_annotations",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lift_indented_constructs",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "delete_statements",
+          "runs": 4,
+          "calls": 3,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_statements_with_pass",
+          "runs": 4,
+          "calls": 4,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(1, 10)",
+          "runs": 2,
+          "calls": 3,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b';')/block_deletion(1, 10)",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "debracket",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "delete_byte_spans",
+          "runs": 3,
+          "calls": 53,
+          "reductions": 4,
+          "bytes_deleted": 8
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(11, 20)",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "tokenize/block_deletion(1, 20)",
+          "runs": 2,
+          "calls": 26,
+          "reductions": 2,
+          "bytes_deleted": 6
+        },
+        {
+          "pass": "reduce_integer_literals",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_falsey_with_zero",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "combine_expressions",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "merge_adjacent_strings",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lexeme_based_deletions",
+          "runs": 2,
+          "calls": 8,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "short_deletions",
+          "runs": 2,
+          "calls": 396,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "normalize_identifiers",
+          "runs": 2,
+          "calls": 2,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "line_sorter",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(21, 100)",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_space_with_newlines",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_bytes",
+          "runs": 1,
+          "calls": 228,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_individual_bytes",
+          "runs": 1,
+          "calls": 246,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "simplify_brackets",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "standard_substitutions",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        }
+      ]
+    },
+    {
+      "name": "already_minimal",
+      "initial_size": 37,
+      "final_size": 34,
+      "calls": 799,
+      "c90": 54,
+      "c99": 54,
+      "tail": 745,
+      "reductions": 2,
+      "seconds": 0.35,
+      "pass_stats": [
+        {
+          "pass": "cut_comment_like_things",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "hollow",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/delete_duplicates",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(10, 100)",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lift_braces",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "remove_indents",
+          "runs": 5,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "remove_whitespace",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_bodies_with_ellipsis",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "strip_annotations",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lift_indented_constructs",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "delete_statements",
+          "runs": 3,
+          "calls": 1,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_statements_with_pass",
+          "runs": 3,
+          "calls": 2,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(1, 10)",
+          "runs": 2,
+          "calls": 1,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b';')/block_deletion(1, 10)",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "debracket",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "delete_byte_spans",
+          "runs": 3,
+          "calls": 32,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(11, 20)",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "tokenize/block_deletion(1, 20)",
+          "runs": 2,
+          "calls": 16,
+          "reductions": 2,
+          "bytes_deleted": 3
+        },
+        {
+          "pass": "reduce_integer_literals",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_falsey_with_zero",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "combine_expressions",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "merge_adjacent_strings",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lexeme_based_deletions",
+          "runs": 2,
+          "calls": 5,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "short_deletions",
+          "runs": 2,
+          "calls": 261,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "normalize_identifiers",
+          "runs": 2,
+          "calls": 2,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "line_sorter",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(21, 100)",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_space_with_newlines",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_bytes",
+          "runs": 1,
+          "calls": 230,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_individual_bytes",
+          "runs": 1,
+          "calls": 242,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "simplify_brackets",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "standard_substitutions",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        }
+      ]
+    },
+    {
+      "name": "python_syntax",
+      "initial_size": 10078,
+      "final_size": 13,
+      "calls": 503,
+      "c90": 19,
+      "c99": 89,
+      "tail": 384,
+      "reductions": 23,
+      "seconds": 1.26,
+      "pass_stats": [
+        {
+          "pass": "cut_comment_like_things",
+          "runs": 4,
+          "calls": 1,
+          "reductions": 1,
+          "bytes_deleted": 45
+        },
+        {
+          "pass": "hollow",
+          "runs": 7,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/delete_duplicates",
+          "runs": 7,
+          "calls": 5,
+          "reductions": 3,
+          "bytes_deleted": 3424
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(10, 100)",
+          "runs": 3,
+          "calls": 46,
+          "reductions": 8,
+          "bytes_deleted": 6388
+        },
+        {
+          "pass": "lift_braces",
+          "runs": 7,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "remove_indents",
+          "runs": 9,
+          "calls": 6,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "remove_whitespace",
+          "runs": 5,
+          "calls": 12,
+          "reductions": 3,
+          "bytes_deleted": 23
+        },
+        {
+          "pass": "replace_bodies_with_ellipsis",
+          "runs": 7,
+          "calls": 1,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "strip_annotations",
+          "runs": 7,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lift_indented_constructs",
+          "runs": 7,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "delete_statements",
+          "runs": 7,
+          "calls": 4,
+          "reductions": 3,
+          "bytes_deleted": 46
+        },
+        {
+          "pass": "replace_statements_with_pass",
+          "runs": 7,
+          "calls": 3,
+          "reductions": 1,
+          "bytes_deleted": 12
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(1, 10)",
+          "runs": 5,
+          "calls": 6,
+          "reductions": 2,
+          "bytes_deleted": 105
+        },
+        {
+          "pass": "split(b';')/block_deletion(1, 10)",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "debracket",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "delete_byte_spans",
+          "runs": 3,
+          "calls": 26,
+          "reductions": 1,
+          "bytes_deleted": 5
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(11, 20)",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "tokenize/block_deletion(1, 20)",
+          "runs": 2,
+          "calls": 4,
+          "reductions": 1,
+          "bytes_deleted": 17
+        },
+        {
+          "pass": "reduce_integer_literals",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_falsey_with_zero",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "combine_expressions",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "merge_adjacent_strings",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lexeme_based_deletions",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "short_deletions",
+          "runs": 2,
+          "calls": 78,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "normalize_identifiers",
+          "runs": 2,
+          "calls": 2,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "line_sorter",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(21, 100)",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_space_with_newlines",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_bytes",
+          "runs": 1,
+          "calls": 214,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_individual_bytes",
+          "runs": 1,
+          "calls": 88,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "simplify_brackets",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "standard_substitutions",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        }
+      ]
+    },
+    {
+      "name": "corpus_mypy",
+      "initial_size": 2537,
+      "final_size": 34,
+      "calls": 3382,
+      "c90": 403,
+      "c99": 847,
+      "tail": 883,
+      "reductions": 72,
+      "seconds": 1.8,
+      "pass_stats": [
+        {
+          "pass": "cut_comment_like_things",
+          "runs": 5,
+          "calls": 13,
+          "reductions": 6,
+          "bytes_deleted": 910
+        },
+        {
+          "pass": "hollow",
+          "runs": 9,
+          "calls": 40,
+          "reductions": 9,
+          "bytes_deleted": 357
+        },
+        {
+          "pass": "split(b'\\n')/delete_duplicates",
+          "runs": 9,
+          "calls": 2,
+          "reductions": 1,
+          "bytes_deleted": 32
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(10, 100)",
+          "runs": 3,
+          "calls": 261,
+          "reductions": 1,
+          "bytes_deleted": 618
+        },
+        {
+          "pass": "lift_braces",
+          "runs": 9,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "remove_indents",
+          "runs": 13,
+          "calls": 29,
+          "reductions": 2,
+          "bytes_deleted": 8
+        },
+        {
+          "pass": "remove_whitespace",
+          "runs": 7,
+          "calls": 94,
+          "reductions": 8,
+          "bytes_deleted": 57
+        },
+        {
+          "pass": "replace_bodies_with_ellipsis",
+          "runs": 9,
+          "calls": 3,
+          "reductions": 3,
+          "bytes_deleted": 187
+        },
+        {
+          "pass": "strip_annotations",
+          "runs": 9,
+          "calls": 10,
+          "reductions": 7,
+          "bytes_deleted": 82
+        },
+        {
+          "pass": "lift_indented_constructs",
+          "runs": 9,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "delete_statements",
+          "runs": 9,
+          "calls": 1,
+          "reductions": 1,
+          "bytes_deleted": 21
+        },
+        {
+          "pass": "replace_statements_with_pass",
+          "runs": 9,
+          "calls": 3,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(1, 10)",
+          "runs": 7,
+          "calls": 35,
+          "reductions": 2,
+          "bytes_deleted": 152
+        },
+        {
+          "pass": "split(b';')/block_deletion(1, 10)",
+          "runs": 6,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "debracket",
+          "runs": 7,
+          "calls": 21,
+          "reductions": 2,
+          "bytes_deleted": 4
+        },
+        {
+          "pass": "delete_byte_spans",
+          "runs": 6,
+          "calls": 181,
+          "reductions": 14,
+          "bytes_deleted": 43
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(11, 20)",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "tokenize/block_deletion(1, 20)",
+          "runs": 4,
+          "calls": 841,
+          "reductions": 4,
+          "bytes_deleted": 27
+        },
+        {
+          "pass": "reduce_integer_literals",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_falsey_with_zero",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "combine_expressions",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "merge_adjacent_strings",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lexeme_based_deletions",
+          "runs": 4,
+          "calls": 16,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "short_deletions",
+          "runs": 4,
+          "calls": 765,
+          "reductions": 3,
+          "bytes_deleted": 5
+        },
+        {
+          "pass": "normalize_identifiers",
+          "runs": 4,
+          "calls": 65,
+          "reductions": 3,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "line_sorter",
+          "runs": 4,
+          "calls": 2,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(21, 100)",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_space_with_newlines",
+          "runs": 2,
+          "calls": 9,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_bytes",
+          "runs": 2,
+          "calls": 476,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_individual_bytes",
+          "runs": 2,
+          "calls": 506,
+          "reductions": 6,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "simplify_brackets",
+          "runs": 2,
+          "calls": 2,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "standard_substitutions",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        }
+      ]
+    },
+    {
+      "name": "corpus_pylint",
+      "initial_size": 2403,
+      "final_size": 44,
+      "calls": 3454,
+      "c90": 187,
+      "c99": 1170,
+      "tail": 1131,
+      "reductions": 58,
+      "seconds": 1.4,
+      "pass_stats": [
+        {
+          "pass": "cut_comment_like_things",
+          "runs": 5,
+          "calls": 26,
+          "reductions": 9,
+          "bytes_deleted": 1139
+        },
+        {
+          "pass": "hollow",
+          "runs": 8,
+          "calls": 29,
+          "reductions": 10,
+          "bytes_deleted": 447
+        },
+        {
+          "pass": "split(b'\\n')/delete_duplicates",
+          "runs": 8,
+          "calls": 1,
+          "reductions": 1,
+          "bytes_deleted": 18
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(10, 100)",
+          "runs": 3,
+          "calls": 131,
+          "reductions": 1,
+          "bytes_deleted": 418
+        },
+        {
+          "pass": "lift_braces",
+          "runs": 8,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "remove_indents",
+          "runs": 11,
+          "calls": 8,
+          "reductions": 3,
+          "bytes_deleted": 16
+        },
+        {
+          "pass": "remove_whitespace",
+          "runs": 6,
+          "calls": 1,
+          "reductions": 1,
+          "bytes_deleted": 28
+        },
+        {
+          "pass": "replace_bodies_with_ellipsis",
+          "runs": 8,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "strip_annotations",
+          "runs": 8,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lift_indented_constructs",
+          "runs": 8,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "delete_statements",
+          "runs": 8,
+          "calls": 5,
+          "reductions": 5,
+          "bytes_deleted": 116
+        },
+        {
+          "pass": "replace_statements_with_pass",
+          "runs": 8,
+          "calls": 1,
+          "reductions": 1,
+          "bytes_deleted": 10
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(1, 10)",
+          "runs": 6,
+          "calls": 19,
+          "reductions": 2,
+          "bytes_deleted": 75
+        },
+        {
+          "pass": "split(b';')/block_deletion(1, 10)",
+          "runs": 5,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "debracket",
+          "runs": 6,
+          "calls": 22,
+          "reductions": 2,
+          "bytes_deleted": 4
+        },
+        {
+          "pass": "delete_byte_spans",
+          "runs": 5,
+          "calls": 196,
+          "reductions": 11,
+          "bytes_deleted": 52
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(11, 20)",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "tokenize/block_deletion(1, 20)",
+          "runs": 3,
+          "calls": 1119,
+          "reductions": 2,
+          "bytes_deleted": 10
+        },
+        {
+          "pass": "reduce_integer_literals",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_falsey_with_zero",
+          "runs": 3,
+          "calls": 1,
+          "reductions": 1,
+          "bytes_deleted": 1
+        },
+        {
+          "pass": "combine_expressions",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "merge_adjacent_strings",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lexeme_based_deletions",
+          "runs": 3,
+          "calls": 24,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "short_deletions",
+          "runs": 3,
+          "calls": 980,
+          "reductions": 3,
+          "bytes_deleted": 9
+        },
+        {
+          "pass": "normalize_identifiers",
+          "runs": 3,
+          "calls": 47,
+          "reductions": 5,
+          "bytes_deleted": 16
+        },
+        {
+          "pass": "line_sorter",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(21, 100)",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_space_with_newlines",
+          "runs": 2,
+          "calls": 5,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_bytes",
+          "runs": 2,
+          "calls": 467,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_individual_bytes",
+          "runs": 2,
+          "calls": 365,
+          "reductions": 1,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "simplify_brackets",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "standard_substitutions",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        }
+      ]
+    },
+    {
+      "name": "corpus_ujson",
+      "initial_size": 826,
+      "final_size": 42,
+      "calls": 1226,
+      "c90": 64,
+      "c99": 68,
+      "tail": 791,
+      "reductions": 23,
+      "seconds": 0.14,
+      "pass_stats": [
+        {
+          "pass": "cut_comment_like_things",
+          "runs": 3,
+          "calls": 1,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "hollow",
+          "runs": 4,
+          "calls": 88,
+          "reductions": 18,
+          "bytes_deleted": 682
+        },
+        {
+          "pass": "split(b'\\n')/delete_duplicates",
+          "runs": 4,
+          "calls": 1,
+          "reductions": 1,
+          "bytes_deleted": 60
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(10, 100)",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lift_braces",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "remove_indents",
+          "runs": 6,
+          "calls": 1,
+          "reductions": 1,
+          "bytes_deleted": 8
+        },
+        {
+          "pass": "remove_whitespace",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "JSON/delete_identifiers",
+          "runs": 4,
+          "calls": 3,
+          "reductions": 1,
+          "bytes_deleted": 32
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(1, 10)",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b';')/block_deletion(1, 10)",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "debracket",
+          "runs": 2,
+          "calls": 5,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "delete_byte_spans",
+          "runs": 3,
+          "calls": 13,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(11, 20)",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "tokenize/block_deletion(1, 20)",
+          "runs": 2,
+          "calls": 548,
+          "reductions": 1,
+          "bytes_deleted": 1
+        },
+        {
+          "pass": "reduce_integer_literals",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_falsey_with_zero",
+          "runs": 2,
+          "calls": 3,
+          "reductions": 1,
+          "bytes_deleted": 1
+        },
+        {
+          "pass": "combine_expressions",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "merge_adjacent_strings",
+          "runs": 2,
+          "calls": 1,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lexeme_based_deletions",
+          "runs": 2,
+          "calls": 3,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "short_deletions",
+          "runs": 2,
+          "calls": 122,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "normalize_identifiers",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "line_sorter",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(21, 100)",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_space_with_newlines",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_bytes",
+          "runs": 1,
+          "calls": 189,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_individual_bytes",
+          "runs": 1,
+          "calls": 237,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "simplify_brackets",
+          "runs": 1,
+          "calls": 4,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "standard_substitutions",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        }
+      ]
+    },
+    {
+      "name": "corpus_udlit_cpp",
+      "initial_size": 834,
+      "final_size": 22,
+      "calls": 806,
+      "c90": 60,
+      "c99": 135,
+      "tail": 587,
+      "reductions": 41,
+      "seconds": 0.08,
+      "pass_stats": [
+        {
+          "pass": "cut_comment_like_things",
+          "runs": 4,
+          "calls": 2,
+          "reductions": 2,
+          "bytes_deleted": 308
+        },
+        {
+          "pass": "hollow",
+          "runs": 7,
+          "calls": 13,
+          "reductions": 7,
+          "bytes_deleted": 190
+        },
+        {
+          "pass": "split(b'\\n')/delete_duplicates",
+          "runs": 7,
+          "calls": 2,
+          "reductions": 2,
+          "bytes_deleted": 82
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(10, 100)",
+          "runs": 3,
+          "calls": 3,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lift_braces",
+          "runs": 7,
+          "calls": 1,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "remove_indents",
+          "runs": 9,
+          "calls": 1,
+          "reductions": 1,
+          "bytes_deleted": 1
+        },
+        {
+          "pass": "remove_whitespace",
+          "runs": 5,
+          "calls": 1,
+          "reductions": 1,
+          "bytes_deleted": 3
+        },
+        {
+          "pass": "replace_function_bodies",
+          "runs": 7,
+          "calls": 4,
+          "reductions": 4,
+          "bytes_deleted": 46
+        },
+        {
+          "pass": "delete_function_definitions",
+          "runs": 7,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "remove_namespaces",
+          "runs": 7,
+          "calls": 2,
+          "reductions": 1,
+          "bytes_deleted": 18
+        },
+        {
+          "pass": "remove_base_classes",
+          "runs": 7,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "remove_constructor_initializers",
+          "runs": 7,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "remove_template_parts",
+          "runs": 7,
+          "calls": 14,
+          "reductions": 3,
+          "bytes_deleted": 27
+        },
+        {
+          "pass": "simplify_call_expressions",
+          "runs": 7,
+          "calls": 4,
+          "reductions": 4,
+          "bytes_deleted": 33
+        },
+        {
+          "pass": "replace_type_with_int",
+          "runs": 7,
+          "calls": 2,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(1, 10)",
+          "runs": 5,
+          "calls": 13,
+          "reductions": 2,
+          "bytes_deleted": 34
+        },
+        {
+          "pass": "split(b';')/block_deletion(1, 10)",
+          "runs": 5,
+          "calls": 7,
+          "reductions": 1,
+          "bytes_deleted": 1
+        },
+        {
+          "pass": "debracket",
+          "runs": 4,
+          "calls": 1,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "delete_byte_spans",
+          "runs": 3,
+          "calls": 66,
+          "reductions": 10,
+          "bytes_deleted": 64
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(11, 20)",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "tokenize/block_deletion(1, 20)",
+          "runs": 2,
+          "calls": 94,
+          "reductions": 3,
+          "bytes_deleted": 5
+        },
+        {
+          "pass": "reduce_integer_literals",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_falsey_with_zero",
+          "runs": 2,
+          "calls": 1,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "combine_expressions",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "merge_adjacent_strings",
+          "runs": 2,
+          "calls": 1,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lexeme_based_deletions",
+          "runs": 2,
+          "calls": 3,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "short_deletions",
+          "runs": 2,
+          "calls": 162,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "normalize_identifiers",
+          "runs": 2,
+          "calls": 5,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "line_sorter",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(21, 100)",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_space_with_newlines",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_bytes",
+          "runs": 1,
+          "calls": 233,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_individual_bytes",
+          "runs": 1,
+          "calls": 164,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "simplify_brackets",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "standard_substitutions",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        }
+      ]
+    },
+    {
+      "name": "corpus_minisat",
+      "initial_size": 2326,
+      "final_size": 10,
+      "calls": 1241,
+      "c90": 795,
+      "c99": 795,
+      "tail": 385,
+      "reductions": 4,
+      "seconds": 0.37,
+      "pass_stats": [
+        {
+          "pass": "cut_comment_like_things",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "hollow",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/delete_duplicates",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(10, 100)",
+          "runs": 2,
+          "calls": 789,
+          "reductions": 2,
+          "bytes_deleted": 2308
+        },
+        {
+          "pass": "lift_braces",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "remove_indents",
+          "runs": 6,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "remove_whitespace",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "DimacsCNF/sort_clauses",
+          "runs": 4,
+          "calls": 1,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "DimacsCNF/force_literals",
+          "runs": 4,
+          "calls": 6,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "DimacsCNF/pass_to_component",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "DimacsCNF/unit_propagate",
+          "runs": 4,
+          "calls": 2,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "DimacsCNF/delete_literals",
+          "runs": 4,
+          "calls": 4,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "DimacsCNF/delete_single_terms",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "DimacsCNF/delete_elements",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "DimacsCNF/flip_literal_signs",
+          "runs": 4,
+          "calls": 2,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "DimacsCNF/combine_clauses",
+          "runs": 4,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "DimacsCNF/merge_literals",
+          "runs": 4,
+          "calls": 6,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "DimacsCNF/renumber_variables",
+          "runs": 4,
+          "calls": 47,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(1, 10)",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b';')/block_deletion(1, 10)",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "debracket",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "delete_byte_spans",
+          "runs": 3,
+          "calls": 15,
+          "reductions": 2,
+          "bytes_deleted": 8
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(11, 20)",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "tokenize/block_deletion(1, 20)",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "reduce_integer_literals",
+          "runs": 2,
+          "calls": 61,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_falsey_with_zero",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "combine_expressions",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "merge_adjacent_strings",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lexeme_based_deletions",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "short_deletions",
+          "runs": 2,
+          "calls": 49,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "normalize_identifiers",
+          "runs": 2,
+          "calls": 2,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "line_sorter",
+          "runs": 2,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "split(b'\\n')/block_deletion(21, 100)",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_space_with_newlines",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_bytes",
+          "runs": 1,
+          "calls": 192,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_individual_bytes",
+          "runs": 1,
+          "calls": 58,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "simplify_brackets",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "standard_substitutions",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        }
+      ]
+    }
+  ]
+}

--- a/evaluation/benchmark_baseline.json
+++ b/evaluation/benchmark_baseline.json
@@ -4,12 +4,12 @@
       "name": "deep_parens",
       "initial_size": 3794,
       "final_size": 800,
-      "calls": 14167,
-      "c90": 11267,
-      "c99": 11475,
+      "calls": 12866,
+      "c90": 9469,
+      "c99": 10131,
       "tail": 2666,
-      "reductions": 1132,
-      "seconds": 5.97,
+      "reductions": 1122,
+      "seconds": 97.96,
       "pass_stats": [
         {
           "pass": "cut_comment_like_things",
@@ -20,7 +20,7 @@
         },
         {
           "pass": "hollow",
-          "runs": 6,
+          "runs": 7,
           "calls": 1,
           "reductions": 1,
           "bytes_deleted": 15
@@ -41,7 +41,7 @@
         },
         {
           "pass": "lift_braces",
-          "runs": 6,
+          "runs": 7,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
@@ -69,7 +69,7 @@
         },
         {
           "pass": "split(b';')/block_deletion(1, 10)",
-          "runs": 4,
+          "runs": 5,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
@@ -77,20 +77,69 @@
         {
           "pass": "debracket",
           "runs": 5,
-          "calls": 603,
+          "calls": 656,
           "reductions": 200,
           "bytes_deleted": 400
         },
         {
           "pass": "delete_byte_spans",
-          "runs": 3,
-          "calls": 783,
-          "reductions": 525,
-          "bytes_deleted": 1210
+          "runs": 4,
+          "calls": 787,
+          "reductions": 514,
+          "bytes_deleted": 1211
         },
         {
           "pass": "split(b'\\n')/block_deletion(11, 20)",
-          "runs": 2,
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "reduce_integer_literals",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_falsey_with_zero",
+          "runs": 3,
+          "calls": 1,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "combine_expressions",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "merge_adjacent_strings",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lexeme_based_deletions",
+          "runs": 3,
+          "calls": 432,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "normalize_identifiers",
+          "runs": 3,
+          "calls": 3,
+          "reductions": 2,
+          "bytes_deleted": 801
+        },
+        {
+          "pass": "line_sorter",
+          "runs": 3,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
@@ -98,65 +147,9 @@
         {
           "pass": "tokenize/block_deletion(1, 20)",
           "runs": 2,
-          "calls": 10251,
-          "reductions": 401,
-          "bytes_deleted": 1202
-        },
-        {
-          "pass": "reduce_integer_literals",
-          "runs": 2,
-          "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "replace_falsey_with_zero",
-          "runs": 2,
-          "calls": 1,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "combine_expressions",
-          "runs": 2,
-          "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "merge_adjacent_strings",
-          "runs": 2,
-          "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "lexeme_based_deletions",
-          "runs": 2,
-          "calls": 11,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "short_deletions",
-          "runs": 2,
-          "calls": 64,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "normalize_identifiers",
-          "runs": 2,
-          "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "line_sorter",
-          "runs": 2,
-          "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
+          "calls": 8533,
+          "reductions": 400,
+          "bytes_deleted": 400
         },
         {
           "pass": "split(b'\\n')/block_deletion(21, 100)",
@@ -167,6 +160,27 @@
         },
         {
           "pass": "replace_space_with_newlines",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "simplify_brackets",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "standard_substitutions",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "short_deletions",
           "runs": 1,
           "calls": 0,
           "reductions": 0,
@@ -185,20 +199,6 @@
           "calls": 2400,
           "reductions": 0,
           "bytes_deleted": 0
-        },
-        {
-          "pass": "simplify_brackets",
-          "runs": 1,
-          "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "standard_substitutions",
-          "runs": 1,
-          "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
         }
       ]
     },
@@ -206,12 +206,12 @@
       "name": "keep_markers",
       "initial_size": 174747,
       "final_size": 50,
-      "calls": 1163,
+      "calls": 1231,
       "c90": 74,
       "c99": 132,
-      "tail": 884,
-      "reductions": 110,
-      "seconds": 10.06,
+      "tail": 886,
+      "reductions": 113,
+      "seconds": 27.34,
       "pass_stats": [
         {
           "pass": "cut_comment_like_things",
@@ -250,100 +250,93 @@
         },
         {
           "pass": "remove_indents",
-          "runs": 6,
+          "runs": 5,
           "calls": 1,
           "reductions": 1,
           "bytes_deleted": 8
         },
         {
           "pass": "remove_whitespace",
-          "runs": 4,
+          "runs": 5,
           "calls": 1,
           "reductions": 1,
           "bytes_deleted": 4
         },
         {
           "pass": "replace_bodies_with_ellipsis",
-          "runs": 4,
+          "runs": 3,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "strip_annotations",
-          "runs": 4,
+          "runs": 3,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "lift_indented_constructs",
-          "runs": 4,
+          "runs": 3,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "delete_statements",
-          "runs": 4,
+          "runs": 3,
           "calls": 3,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "replace_statements_with_pass",
-          "runs": 4,
+          "runs": 3,
           "calls": 4,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "split(b'\\n')/block_deletion(1, 10)",
-          "runs": 2,
-          "calls": 3,
+          "runs": 3,
+          "calls": 7,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "split(b';')/block_deletion(1, 10)",
-          "runs": 2,
+          "runs": 3,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "debracket",
-          "runs": 2,
+          "runs": 3,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "delete_byte_spans",
-          "runs": 3,
-          "calls": 53,
+          "runs": 4,
+          "calls": 132,
           "reductions": 4,
           "bytes_deleted": 8
         },
         {
           "pass": "split(b'\\n')/block_deletion(11, 20)",
-          "runs": 2,
+          "runs": 3,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
-          "pass": "tokenize/block_deletion(1, 20)",
-          "runs": 2,
-          "calls": 26,
-          "reductions": 2,
-          "bytes_deleted": 6
-        },
-        {
           "pass": "reduce_integer_literals",
-          "runs": 2,
-          "calls": 0,
-          "reductions": 0,
+          "runs": 3,
+          "calls": 3,
+          "reductions": 3,
           "bytes_deleted": 0
         },
         {
@@ -370,21 +363,14 @@
         {
           "pass": "lexeme_based_deletions",
           "runs": 2,
-          "calls": 8,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "short_deletions",
-          "runs": 2,
-          "calls": 396,
+          "calls": 17,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "normalize_identifiers",
           "runs": 2,
-          "calls": 2,
+          "calls": 14,
           "reductions": 0,
           "bytes_deleted": 0
         },
@@ -394,6 +380,13 @@
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
+        },
+        {
+          "pass": "tokenize/block_deletion(1, 20)",
+          "runs": 2,
+          "calls": 21,
+          "reductions": 2,
+          "bytes_deleted": 6
         },
         {
           "pass": "split(b'\\n')/block_deletion(21, 100)",
@@ -410,20 +403,6 @@
           "bytes_deleted": 0
         },
         {
-          "pass": "lower_bytes",
-          "runs": 1,
-          "calls": 228,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "lower_individual_bytes",
-          "runs": 1,
-          "calls": 246,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
           "pass": "simplify_brackets",
           "runs": 1,
           "calls": 0,
@@ -436,6 +415,27 @@
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
+        },
+        {
+          "pass": "short_deletions",
+          "runs": 1,
+          "calls": 360,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_bytes",
+          "runs": 1,
+          "calls": 233,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_individual_bytes",
+          "runs": 1,
+          "calls": 243,
+          "reductions": 0,
+          "bytes_deleted": 0
         }
       ]
     },
@@ -443,12 +443,12 @@
       "name": "already_minimal",
       "initial_size": 37,
       "final_size": 34,
-      "calls": 799,
-      "c90": 54,
-      "c99": 54,
-      "tail": 745,
-      "reductions": 2,
-      "seconds": 0.35,
+      "calls": 844,
+      "c90": 102,
+      "c99": 102,
+      "tail": 742,
+      "reductions": 3,
+      "seconds": 4.14,
       "pass_stats": [
         {
           "pass": "cut_comment_like_things",
@@ -487,7 +487,7 @@
         },
         {
           "pass": "remove_indents",
-          "runs": 5,
+          "runs": 3,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
@@ -523,47 +523,96 @@
         {
           "pass": "delete_statements",
           "runs": 3,
-          "calls": 1,
+          "calls": 2,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "replace_statements_with_pass",
           "runs": 3,
-          "calls": 2,
+          "calls": 3,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "split(b'\\n')/block_deletion(1, 10)",
-          "runs": 2,
-          "calls": 1,
+          "runs": 3,
+          "calls": 3,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "split(b';')/block_deletion(1, 10)",
-          "runs": 2,
+          "runs": 3,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "debracket",
-          "runs": 2,
+          "runs": 3,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "delete_byte_spans",
-          "runs": 3,
-          "calls": 32,
+          "runs": 4,
+          "calls": 86,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "split(b'\\n')/block_deletion(11, 20)",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "reduce_integer_literals",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_falsey_with_zero",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "combine_expressions",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "merge_adjacent_strings",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lexeme_based_deletions",
+          "runs": 3,
+          "calls": 6,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "normalize_identifiers",
+          "runs": 3,
+          "calls": 17,
+          "reductions": 1,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "line_sorter",
           "runs": 2,
           "calls": 0,
           "reductions": 0,
@@ -577,62 +626,6 @@
           "bytes_deleted": 3
         },
         {
-          "pass": "reduce_integer_literals",
-          "runs": 2,
-          "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "replace_falsey_with_zero",
-          "runs": 2,
-          "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "combine_expressions",
-          "runs": 2,
-          "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "merge_adjacent_strings",
-          "runs": 2,
-          "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "lexeme_based_deletions",
-          "runs": 2,
-          "calls": 5,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "short_deletions",
-          "runs": 2,
-          "calls": 261,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "normalize_identifiers",
-          "runs": 2,
-          "calls": 2,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "line_sorter",
-          "runs": 2,
-          "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
           "pass": "split(b'\\n')/block_deletion(21, 100)",
           "runs": 1,
           "calls": 0,
@@ -643,20 +636,6 @@
           "pass": "replace_space_with_newlines",
           "runs": 1,
           "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "lower_bytes",
-          "runs": 1,
-          "calls": 230,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "lower_individual_bytes",
-          "runs": 1,
-          "calls": 242,
           "reductions": 0,
           "bytes_deleted": 0
         },
@@ -673,6 +652,27 @@
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
+        },
+        {
+          "pass": "short_deletions",
+          "runs": 1,
+          "calls": 236,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_bytes",
+          "runs": 1,
+          "calls": 227,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_individual_bytes",
+          "runs": 1,
+          "calls": 241,
+          "reductions": 0,
+          "bytes_deleted": 0
         }
       ]
     },
@@ -680,12 +680,12 @@
       "name": "python_syntax",
       "initial_size": 10078,
       "final_size": 13,
-      "calls": 503,
+      "calls": 540,
       "c90": 19,
       "c99": 89,
-      "tail": 384,
-      "reductions": 23,
-      "seconds": 1.26,
+      "tail": 379,
+      "reductions": 24,
+      "seconds": 15.81,
       "pass_stats": [
         {
           "pass": "cut_comment_like_things",
@@ -696,14 +696,14 @@
         },
         {
           "pass": "hollow",
-          "runs": 7,
+          "runs": 6,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "split(b'\\n')/delete_duplicates",
-          "runs": 7,
+          "runs": 6,
           "calls": 5,
           "reductions": 3,
           "bytes_deleted": 3424
@@ -717,77 +717,77 @@
         },
         {
           "pass": "lift_braces",
-          "runs": 7,
+          "runs": 6,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "remove_indents",
-          "runs": 9,
+          "runs": 7,
           "calls": 6,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "remove_whitespace",
-          "runs": 5,
+          "runs": 6,
           "calls": 12,
           "reductions": 3,
           "bytes_deleted": 23
         },
         {
           "pass": "replace_bodies_with_ellipsis",
-          "runs": 7,
+          "runs": 6,
           "calls": 1,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "strip_annotations",
-          "runs": 7,
+          "runs": 6,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "lift_indented_constructs",
-          "runs": 7,
+          "runs": 6,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "delete_statements",
-          "runs": 7,
+          "runs": 6,
           "calls": 4,
           "reductions": 3,
           "bytes_deleted": 46
         },
         {
           "pass": "replace_statements_with_pass",
-          "runs": 7,
+          "runs": 5,
           "calls": 3,
           "reductions": 1,
           "bytes_deleted": 12
         },
         {
           "pass": "split(b'\\n')/block_deletion(1, 10)",
-          "runs": 5,
+          "runs": 4,
           "calls": 6,
           "reductions": 2,
           "bytes_deleted": 105
         },
         {
           "pass": "split(b';')/block_deletion(1, 10)",
-          "runs": 4,
+          "runs": 3,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "debracket",
-          "runs": 4,
+          "runs": 3,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
@@ -795,12 +795,61 @@
         {
           "pass": "delete_byte_spans",
           "runs": 3,
-          "calls": 26,
+          "calls": 52,
           "reductions": 1,
           "bytes_deleted": 5
         },
         {
           "pass": "split(b'\\n')/block_deletion(11, 20)",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "reduce_integer_literals",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "replace_falsey_with_zero",
+          "runs": 3,
+          "calls": 2,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "combine_expressions",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "merge_adjacent_strings",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lexeme_based_deletions",
+          "runs": 3,
+          "calls": 2,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "normalize_identifiers",
+          "runs": 3,
+          "calls": 24,
+          "reductions": 1,
+          "bytes_deleted": 2
+        },
+        {
+          "pass": "line_sorter",
           "runs": 2,
           "calls": 0,
           "reductions": 0,
@@ -809,65 +858,9 @@
         {
           "pass": "tokenize/block_deletion(1, 20)",
           "runs": 2,
-          "calls": 4,
-          "reductions": 1,
-          "bytes_deleted": 17
-        },
-        {
-          "pass": "reduce_integer_literals",
-          "runs": 2,
-          "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "replace_falsey_with_zero",
-          "runs": 2,
-          "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "combine_expressions",
-          "runs": 2,
-          "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "merge_adjacent_strings",
-          "runs": 2,
-          "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "lexeme_based_deletions",
-          "runs": 2,
-          "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "short_deletions",
-          "runs": 2,
-          "calls": 78,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "normalize_identifiers",
-          "runs": 2,
           "calls": 2,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "line_sorter",
-          "runs": 2,
-          "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
+          "reductions": 1,
+          "bytes_deleted": 15
         },
         {
           "pass": "split(b'\\n')/block_deletion(21, 100)",
@@ -884,20 +877,6 @@
           "bytes_deleted": 0
         },
         {
-          "pass": "lower_bytes",
-          "runs": 1,
-          "calls": 214,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "lower_individual_bytes",
-          "runs": 1,
-          "calls": 88,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
           "pass": "simplify_brackets",
           "runs": 1,
           "calls": 0,
@@ -910,6 +889,27 @@
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
+        },
+        {
+          "pass": "short_deletions",
+          "runs": 1,
+          "calls": 70,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_bytes",
+          "runs": 1,
+          "calls": 212,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_individual_bytes",
+          "runs": 1,
+          "calls": 85,
+          "reductions": 0,
+          "bytes_deleted": 0
         }
       ]
     },
@@ -917,30 +917,30 @@
       "name": "corpus_mypy",
       "initial_size": 2537,
       "final_size": 34,
-      "calls": 3382,
+      "calls": 3386,
       "c90": 403,
-      "c99": 847,
-      "tail": 883,
-      "reductions": 72,
-      "seconds": 1.8,
+      "c99": 667,
+      "tail": 933,
+      "reductions": 75,
+      "seconds": 19.69,
       "pass_stats": [
         {
           "pass": "cut_comment_like_things",
-          "runs": 5,
+          "runs": 6,
           "calls": 13,
           "reductions": 6,
           "bytes_deleted": 910
         },
         {
           "pass": "hollow",
-          "runs": 9,
-          "calls": 40,
+          "runs": 11,
+          "calls": 45,
           "reductions": 9,
           "bytes_deleted": 357
         },
         {
           "pass": "split(b'\\n')/delete_duplicates",
-          "runs": 9,
+          "runs": 10,
           "calls": 2,
           "reductions": 1,
           "bytes_deleted": 32
@@ -954,7 +954,7 @@
         },
         {
           "pass": "lift_braces",
-          "runs": 9,
+          "runs": 11,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
@@ -962,190 +962,190 @@
         {
           "pass": "remove_indents",
           "runs": 13,
-          "calls": 29,
+          "calls": 32,
           "reductions": 2,
           "bytes_deleted": 8
         },
         {
           "pass": "remove_whitespace",
-          "runs": 7,
-          "calls": 94,
+          "runs": 9,
+          "calls": 96,
           "reductions": 8,
           "bytes_deleted": 57
         },
         {
           "pass": "replace_bodies_with_ellipsis",
-          "runs": 9,
+          "runs": 8,
           "calls": 3,
           "reductions": 3,
           "bytes_deleted": 187
         },
         {
           "pass": "strip_annotations",
-          "runs": 9,
-          "calls": 10,
+          "runs": 8,
+          "calls": 12,
           "reductions": 7,
           "bytes_deleted": 82
         },
         {
           "pass": "lift_indented_constructs",
-          "runs": 9,
+          "runs": 8,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "delete_statements",
-          "runs": 9,
+          "runs": 8,
           "calls": 1,
           "reductions": 1,
           "bytes_deleted": 21
         },
         {
           "pass": "replace_statements_with_pass",
-          "runs": 9,
+          "runs": 8,
           "calls": 3,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "split(b'\\n')/block_deletion(1, 10)",
-          "runs": 7,
-          "calls": 35,
+          "runs": 8,
+          "calls": 50,
           "reductions": 2,
           "bytes_deleted": 152
         },
         {
           "pass": "split(b';')/block_deletion(1, 10)",
-          "runs": 6,
+          "runs": 8,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "debracket",
-          "runs": 7,
-          "calls": 21,
-          "reductions": 2,
-          "bytes_deleted": 4
+          "runs": 8,
+          "calls": 32,
+          "reductions": 3,
+          "bytes_deleted": 6
         },
         {
           "pass": "delete_byte_spans",
-          "runs": 6,
-          "calls": 181,
-          "reductions": 14,
-          "bytes_deleted": 43
+          "runs": 9,
+          "calls": 293,
+          "reductions": 15,
+          "bytes_deleted": 47
         },
         {
           "pass": "split(b'\\n')/block_deletion(11, 20)",
-          "runs": 4,
+          "runs": 6,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
-          "pass": "tokenize/block_deletion(1, 20)",
-          "runs": 4,
-          "calls": 841,
-          "reductions": 4,
-          "bytes_deleted": 27
-        },
-        {
           "pass": "reduce_integer_literals",
-          "runs": 4,
+          "runs": 6,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "replace_falsey_with_zero",
-          "runs": 4,
+          "runs": 6,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "combine_expressions",
-          "runs": 4,
+          "runs": 6,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "merge_adjacent_strings",
-          "runs": 4,
+          "runs": 6,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "lexeme_based_deletions",
-          "runs": 4,
-          "calls": 16,
+          "runs": 6,
+          "calls": 40,
           "reductions": 0,
           "bytes_deleted": 0
-        },
-        {
-          "pass": "short_deletions",
-          "runs": 4,
-          "calls": 765,
-          "reductions": 3,
-          "bytes_deleted": 5
         },
         {
           "pass": "normalize_identifiers",
-          "runs": 4,
-          "calls": 65,
-          "reductions": 3,
-          "bytes_deleted": 0
+          "runs": 6,
+          "calls": 172,
+          "reductions": 7,
+          "bytes_deleted": 8
         },
         {
           "pass": "line_sorter",
-          "runs": 4,
-          "calls": 2,
+          "runs": 5,
+          "calls": 6,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
+          "pass": "tokenize/block_deletion(1, 20)",
+          "runs": 5,
+          "calls": 536,
+          "reductions": 2,
+          "bytes_deleted": 16
+        },
+        {
           "pass": "split(b'\\n')/block_deletion(21, 100)",
-          "runs": 2,
+          "runs": 3,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "replace_space_with_newlines",
-          "runs": 2,
-          "calls": 9,
+          "runs": 3,
+          "calls": 12,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
+          "pass": "simplify_brackets",
+          "runs": 3,
+          "calls": 3,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "standard_substitutions",
+          "runs": 3,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "short_deletions",
+          "runs": 3,
+          "calls": 726,
+          "reductions": 2,
+          "bytes_deleted": 2
+        },
+        {
           "pass": "lower_bytes",
-          "runs": 2,
-          "calls": 476,
+          "runs": 4,
+          "calls": 527,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "lower_individual_bytes",
           "runs": 2,
-          "calls": 506,
+          "calls": 514,
           "reductions": 6,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "simplify_brackets",
-          "runs": 2,
-          "calls": 2,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "standard_substitutions",
-          "runs": 2,
-          "calls": 0,
-          "reductions": 0,
           "bytes_deleted": 0
         }
       ]
@@ -1154,12 +1154,12 @@
       "name": "corpus_pylint",
       "initial_size": 2403,
       "final_size": 44,
-      "calls": 3454,
+      "calls": 3009,
       "c90": 187,
-      "c99": 1170,
-      "tail": 1131,
+      "c99": 398,
+      "tail": 1068,
       "reductions": 58,
-      "seconds": 1.4,
+      "seconds": 16.67,
       "pass_stats": [
         {
           "pass": "cut_comment_like_things",
@@ -1170,7 +1170,7 @@
         },
         {
           "pass": "hollow",
-          "runs": 8,
+          "runs": 9,
           "calls": 29,
           "reductions": 10,
           "bytes_deleted": 447
@@ -1191,21 +1191,21 @@
         },
         {
           "pass": "lift_braces",
-          "runs": 8,
+          "runs": 9,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "remove_indents",
-          "runs": 11,
+          "runs": 10,
           "calls": 8,
           "reductions": 3,
           "bytes_deleted": 16
         },
         {
           "pass": "remove_whitespace",
-          "runs": 6,
+          "runs": 8,
           "calls": 1,
           "reductions": 1,
           "bytes_deleted": 28
@@ -1240,7 +1240,7 @@
         },
         {
           "pass": "replace_statements_with_pass",
-          "runs": 8,
+          "runs": 7,
           "calls": 1,
           "reductions": 1,
           "bytes_deleted": 10
@@ -1248,13 +1248,13 @@
         {
           "pass": "split(b'\\n')/block_deletion(1, 10)",
           "runs": 6,
-          "calls": 19,
+          "calls": 23,
           "reductions": 2,
           "bytes_deleted": 75
         },
         {
           "pass": "split(b';')/block_deletion(1, 10)",
-          "runs": 5,
+          "runs": 6,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
@@ -1262,86 +1262,79 @@
         {
           "pass": "debracket",
           "runs": 6,
-          "calls": 22,
+          "calls": 32,
           "reductions": 2,
           "bytes_deleted": 4
         },
         {
           "pass": "delete_byte_spans",
-          "runs": 5,
-          "calls": 196,
-          "reductions": 11,
+          "runs": 7,
+          "calls": 258,
+          "reductions": 10,
           "bytes_deleted": 52
         },
         {
           "pass": "split(b'\\n')/block_deletion(11, 20)",
-          "runs": 3,
+          "runs": 5,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
-          "pass": "tokenize/block_deletion(1, 20)",
-          "runs": 3,
-          "calls": 1119,
-          "reductions": 2,
-          "bytes_deleted": 10
-        },
-        {
           "pass": "reduce_integer_literals",
-          "runs": 3,
+          "runs": 5,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "replace_falsey_with_zero",
-          "runs": 3,
-          "calls": 1,
+          "runs": 5,
+          "calls": 5,
           "reductions": 1,
           "bytes_deleted": 1
         },
         {
           "pass": "combine_expressions",
-          "runs": 3,
+          "runs": 5,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "merge_adjacent_strings",
-          "runs": 3,
-          "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
+          "runs": 5,
+          "calls": 6,
+          "reductions": 2,
+          "bytes_deleted": 6
         },
         {
           "pass": "lexeme_based_deletions",
-          "runs": 3,
-          "calls": 24,
+          "runs": 5,
+          "calls": 41,
           "reductions": 0,
           "bytes_deleted": 0
-        },
-        {
-          "pass": "short_deletions",
-          "runs": 3,
-          "calls": 980,
-          "reductions": 3,
-          "bytes_deleted": 9
         },
         {
           "pass": "normalize_identifiers",
-          "runs": 3,
-          "calls": 47,
+          "runs": 5,
+          "calls": 61,
           "reductions": 5,
-          "bytes_deleted": 16
+          "bytes_deleted": 25
         },
         {
           "pass": "line_sorter",
-          "runs": 3,
-          "calls": 0,
-          "reductions": 0,
+          "runs": 5,
+          "calls": 2,
+          "reductions": 2,
           "bytes_deleted": 0
+        },
+        {
+          "pass": "tokenize/block_deletion(1, 20)",
+          "runs": 4,
+          "calls": 793,
+          "reductions": 1,
+          "bytes_deleted": 4
         },
         {
           "pass": "split(b'\\n')/block_deletion(21, 100)",
@@ -1353,22 +1346,8 @@
         {
           "pass": "replace_space_with_newlines",
           "runs": 2,
-          "calls": 5,
+          "calls": 8,
           "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "lower_bytes",
-          "runs": 2,
-          "calls": 467,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "lower_individual_bytes",
-          "runs": 2,
-          "calls": 365,
-          "reductions": 1,
           "bytes_deleted": 0
         },
         {
@@ -1384,6 +1363,27 @@
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
+        },
+        {
+          "pass": "short_deletions",
+          "runs": 3,
+          "calls": 525,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_bytes",
+          "runs": 3,
+          "calls": 482,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_individual_bytes",
+          "runs": 2,
+          "calls": 564,
+          "reductions": 2,
+          "bytes_deleted": 0
         }
       ]
     },
@@ -1391,12 +1391,12 @@
       "name": "corpus_ujson",
       "initial_size": 826,
       "final_size": 42,
-      "calls": 1226,
+      "calls": 1280,
       "c90": 64,
       "c99": 68,
-      "tail": 791,
+      "tail": 800,
       "reductions": 23,
-      "seconds": 0.14,
+      "seconds": 4.63,
       "pass_stats": [
         {
           "pass": "cut_comment_like_things",
@@ -1408,7 +1408,7 @@
         {
           "pass": "hollow",
           "runs": 4,
-          "calls": 88,
+          "calls": 111,
           "reductions": 18,
           "bytes_deleted": 682
         },
@@ -1435,7 +1435,7 @@
         },
         {
           "pass": "remove_indents",
-          "runs": 6,
+          "runs": 4,
           "calls": 1,
           "reductions": 1,
           "bytes_deleted": 8
@@ -1456,57 +1456,50 @@
         },
         {
           "pass": "split(b'\\n')/block_deletion(1, 10)",
-          "runs": 2,
+          "runs": 3,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "split(b';')/block_deletion(1, 10)",
-          "runs": 2,
+          "runs": 3,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "debracket",
-          "runs": 2,
-          "calls": 5,
+          "runs": 3,
+          "calls": 8,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "delete_byte_spans",
           "runs": 3,
-          "calls": 13,
+          "calls": 27,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "split(b'\\n')/block_deletion(11, 20)",
-          "runs": 2,
+          "runs": 3,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
-          "pass": "tokenize/block_deletion(1, 20)",
-          "runs": 2,
-          "calls": 548,
-          "reductions": 1,
-          "bytes_deleted": 1
-        },
-        {
           "pass": "reduce_integer_literals",
-          "runs": 2,
+          "runs": 3,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "replace_falsey_with_zero",
-          "runs": 2,
-          "calls": 3,
+          "runs": 3,
+          "calls": 4,
           "reductions": 1,
           "bytes_deleted": 1
         },
@@ -1520,21 +1513,14 @@
         {
           "pass": "merge_adjacent_strings",
           "runs": 2,
-          "calls": 1,
+          "calls": 2,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "lexeme_based_deletions",
           "runs": 2,
-          "calls": 3,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "short_deletions",
-          "runs": 2,
-          "calls": 122,
+          "calls": 6,
           "reductions": 0,
           "bytes_deleted": 0
         },
@@ -1553,6 +1539,13 @@
           "bytes_deleted": 0
         },
         {
+          "pass": "tokenize/block_deletion(1, 20)",
+          "runs": 2,
+          "calls": 670,
+          "reductions": 1,
+          "bytes_deleted": 1
+        },
+        {
           "pass": "split(b'\\n')/block_deletion(21, 100)",
           "runs": 1,
           "calls": 0,
@@ -1563,20 +1556,6 @@
           "pass": "replace_space_with_newlines",
           "runs": 1,
           "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "lower_bytes",
-          "runs": 1,
-          "calls": 189,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "lower_individual_bytes",
-          "runs": 1,
-          "calls": 237,
           "reductions": 0,
           "bytes_deleted": 0
         },
@@ -1593,6 +1572,27 @@
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
+        },
+        {
+          "pass": "short_deletions",
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_bytes",
+          "runs": 1,
+          "calls": 197,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_individual_bytes",
+          "runs": 1,
+          "calls": 238,
+          "reductions": 0,
+          "bytes_deleted": 0
         }
       ]
     },
@@ -1600,12 +1600,12 @@
       "name": "corpus_udlit_cpp",
       "initial_size": 834,
       "final_size": 22,
-      "calls": 806,
-      "c90": 60,
-      "c99": 135,
-      "tail": 587,
-      "reductions": 41,
-      "seconds": 0.08,
+      "calls": 904,
+      "c90": 61,
+      "c99": 134,
+      "tail": 591,
+      "reductions": 46,
+      "seconds": 3.11,
       "pass_stats": [
         {
           "pass": "cut_comment_like_things",
@@ -1616,21 +1616,21 @@
         },
         {
           "pass": "hollow",
-          "runs": 7,
+          "runs": 8,
           "calls": 13,
           "reductions": 7,
           "bytes_deleted": 190
         },
         {
           "pass": "split(b'\\n')/delete_duplicates",
-          "runs": 7,
+          "runs": 9,
           "calls": 2,
           "reductions": 2,
           "bytes_deleted": 82
         },
         {
           "pass": "split(b'\\n')/block_deletion(10, 100)",
-          "runs": 3,
+          "runs": 2,
           "calls": 3,
           "reductions": 0,
           "bytes_deleted": 0
@@ -1651,7 +1651,7 @@
         },
         {
           "pass": "remove_whitespace",
-          "runs": 5,
+          "runs": 7,
           "calls": 1,
           "reductions": 1,
           "bytes_deleted": 3
@@ -1714,101 +1714,94 @@
         },
         {
           "pass": "split(b'\\n')/block_deletion(1, 10)",
-          "runs": 5,
-          "calls": 13,
+          "runs": 7,
+          "calls": 24,
           "reductions": 2,
           "bytes_deleted": 34
         },
         {
           "pass": "split(b';')/block_deletion(1, 10)",
-          "runs": 5,
-          "calls": 7,
-          "reductions": 1,
-          "bytes_deleted": 1
+          "runs": 7,
+          "calls": 8,
+          "reductions": 2,
+          "bytes_deleted": 2
         },
         {
           "pass": "debracket",
-          "runs": 4,
+          "runs": 5,
           "calls": 1,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "delete_byte_spans",
-          "runs": 3,
-          "calls": 66,
-          "reductions": 10,
-          "bytes_deleted": 64
+          "runs": 5,
+          "calls": 149,
+          "reductions": 11,
+          "bytes_deleted": 65
         },
         {
           "pass": "split(b'\\n')/block_deletion(11, 20)",
-          "runs": 2,
+          "runs": 5,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
-          "pass": "tokenize/block_deletion(1, 20)",
-          "runs": 2,
-          "calls": 94,
-          "reductions": 3,
-          "bytes_deleted": 5
-        },
-        {
           "pass": "reduce_integer_literals",
-          "runs": 2,
+          "runs": 5,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "replace_falsey_with_zero",
-          "runs": 2,
-          "calls": 1,
+          "runs": 5,
+          "calls": 5,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "combine_expressions",
-          "runs": 2,
+          "runs": 5,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "merge_adjacent_strings",
-          "runs": 2,
-          "calls": 1,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "lexeme_based_deletions",
-          "runs": 2,
-          "calls": 3,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "short_deletions",
-          "runs": 2,
-          "calls": 162,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "normalize_identifiers",
-          "runs": 2,
+          "runs": 5,
           "calls": 5,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
-          "pass": "line_sorter",
-          "runs": 2,
-          "calls": 0,
+          "pass": "lexeme_based_deletions",
+          "runs": 5,
+          "calls": 6,
           "reductions": 0,
           "bytes_deleted": 0
+        },
+        {
+          "pass": "normalize_identifiers",
+          "runs": 5,
+          "calls": 30,
+          "reductions": 1,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "line_sorter",
+          "runs": 5,
+          "calls": 3,
+          "reductions": 3,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "tokenize/block_deletion(1, 20)",
+          "runs": 2,
+          "calls": 79,
+          "reductions": 2,
+          "bytes_deleted": 3
         },
         {
           "pass": "split(b'\\n')/block_deletion(21, 100)",
@@ -1825,20 +1818,6 @@
           "bytes_deleted": 0
         },
         {
-          "pass": "lower_bytes",
-          "runs": 1,
-          "calls": 233,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "lower_individual_bytes",
-          "runs": 1,
-          "calls": 164,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
           "pass": "simplify_brackets",
           "runs": 1,
           "calls": 0,
@@ -1851,6 +1830,27 @@
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
+        },
+        {
+          "pass": "short_deletions",
+          "runs": 1,
+          "calls": 136,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_bytes",
+          "runs": 1,
+          "calls": 233,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_individual_bytes",
+          "runs": 1,
+          "calls": 169,
+          "reductions": 0,
+          "bytes_deleted": 0
         }
       ]
     },
@@ -1858,12 +1858,12 @@
       "name": "corpus_minisat",
       "initial_size": 2326,
       "final_size": 10,
-      "calls": 1241,
+      "calls": 1207,
       "c90": 795,
       "c99": 795,
-      "tail": 385,
+      "tail": 375,
       "reductions": 4,
-      "seconds": 0.37,
+      "seconds": 11.37,
       "pass_stats": [
         {
           "pass": "cut_comment_like_things",
@@ -1874,14 +1874,14 @@
         },
         {
           "pass": "hollow",
-          "runs": 4,
+          "runs": 3,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "split(b'\\n')/delete_duplicates",
-          "runs": 4,
+          "runs": 3,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
@@ -1895,99 +1895,99 @@
         },
         {
           "pass": "lift_braces",
-          "runs": 4,
+          "runs": 2,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "remove_indents",
-          "runs": 6,
+          "runs": 2,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "remove_whitespace",
-          "runs": 4,
+          "runs": 2,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "DimacsCNF/sort_clauses",
-          "runs": 4,
+          "runs": 2,
           "calls": 1,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "DimacsCNF/force_literals",
-          "runs": 4,
+          "runs": 2,
           "calls": 6,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "DimacsCNF/pass_to_component",
-          "runs": 4,
+          "runs": 2,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "DimacsCNF/unit_propagate",
-          "runs": 4,
+          "runs": 2,
           "calls": 2,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "DimacsCNF/delete_literals",
-          "runs": 4,
-          "calls": 4,
+          "runs": 2,
+          "calls": 2,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "DimacsCNF/delete_single_terms",
-          "runs": 4,
+          "runs": 2,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "DimacsCNF/delete_elements",
-          "runs": 4,
+          "runs": 2,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "DimacsCNF/flip_literal_signs",
-          "runs": 4,
+          "runs": 2,
           "calls": 2,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "DimacsCNF/combine_clauses",
-          "runs": 4,
+          "runs": 2,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "DimacsCNF/merge_literals",
-          "runs": 4,
-          "calls": 6,
+          "runs": 2,
+          "calls": 5,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "DimacsCNF/renumber_variables",
-          "runs": 4,
-          "calls": 47,
+          "runs": 2,
+          "calls": 25,
           "reductions": 0,
           "bytes_deleted": 0
         },
@@ -2014,77 +2014,70 @@
         },
         {
           "pass": "delete_byte_spans",
-          "runs": 3,
-          "calls": 15,
+          "runs": 2,
+          "calls": 21,
           "reductions": 2,
           "bytes_deleted": 8
         },
         {
           "pass": "split(b'\\n')/block_deletion(11, 20)",
-          "runs": 2,
-          "calls": 0,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "tokenize/block_deletion(1, 20)",
-          "runs": 2,
+          "runs": 1,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "reduce_integer_literals",
-          "runs": 2,
+          "runs": 1,
           "calls": 61,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "replace_falsey_with_zero",
-          "runs": 2,
+          "runs": 1,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "combine_expressions",
-          "runs": 2,
+          "runs": 1,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "merge_adjacent_strings",
-          "runs": 2,
+          "runs": 1,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "lexeme_based_deletions",
-          "runs": 2,
+          "runs": 1,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
-          "pass": "short_deletions",
-          "runs": 2,
-          "calls": 49,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
           "pass": "normalize_identifiers",
-          "runs": 2,
+          "runs": 1,
           "calls": 2,
           "reductions": 0,
           "bytes_deleted": 0
         },
         {
           "pass": "line_sorter",
-          "runs": 2,
+          "runs": 1,
+          "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "tokenize/block_deletion(1, 20)",
+          "runs": 1,
           "calls": 0,
           "reductions": 0,
           "bytes_deleted": 0
@@ -2104,20 +2097,6 @@
           "bytes_deleted": 0
         },
         {
-          "pass": "lower_bytes",
-          "runs": 1,
-          "calls": 192,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
-          "pass": "lower_individual_bytes",
-          "runs": 1,
-          "calls": 58,
-          "reductions": 0,
-          "bytes_deleted": 0
-        },
-        {
           "pass": "simplify_brackets",
           "runs": 1,
           "calls": 0,
@@ -2128,6 +2107,27 @@
           "pass": "standard_substitutions",
           "runs": 1,
           "calls": 0,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "short_deletions",
+          "runs": 1,
+          "calls": 43,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_bytes",
+          "runs": 1,
+          "calls": 186,
+          "reductions": 0,
+          "bytes_deleted": 0
+        },
+        {
+          "pass": "lower_individual_bytes",
+          "runs": 1,
+          "calls": 55,
           "reductions": 0,
           "bytes_deleted": 0
         }

--- a/evaluation/watch.py
+++ b/evaluation/watch.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Run one corpus entry interactively in shrink ray's normal interface.
+
+Unlike run.py — which runs headless with `--ui=basic`, resumes any
+in-progress reduction, and records results — this is for *watching*:
+it always resets the starting point to the entry's original input,
+launches shrink ray attached to your terminal (so you get the TUI),
+and records nothing. It reduces a separate work file
+(<entry>/work/watch<ext>), so it never disturbs run.py's resumable
+state or the committed shrinkray_reduced.* / result.json.
+
+Any unrecognised arguments are forwarded to shrinkray, e.g.:
+
+    python3 evaluation/watch.py ruff-0.0.277-isort-skip-block-panic
+    python3 evaluation/watch.py corpus-entry-id --parallelism 4
+    python3 evaluation/watch.py corpus-entry-id --ui=basic
+"""
+
+import argparse
+import shlex
+import shutil
+import subprocess
+import sys
+
+from run import (
+    CORPUS_DIR,
+    REPO_ROOT,
+    is_interesting,
+    load_entries,
+    original_path,
+    prepare,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("id", help="corpus entry id")
+    parser.add_argument(
+        "--parallelism", type=int, default=None,
+        help="override the entry's parallelism setting",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="set up the oracle and print the shrinkray command instead of running it",
+    )
+    args, extra = parser.parse_known_args()
+
+    entries = load_entries([args.id])
+    if not entries:
+        available = ", ".join(p.parent.name for p in sorted(CORPUS_DIR.glob("*/meta.json")))
+        print(f"no corpus entry named {args.id!r}", file=sys.stderr)
+        print(f"available entries: {available}", file=sys.stderr)
+        return 2
+    entry = entries[0]
+
+    if entry["oracle"]["type"] == "docker" and shutil.which("docker") is None:
+        print("docker not found on PATH", file=sys.stderr)
+        return 2
+
+    print(f"Setting up oracle for {entry['id']} ({entry['tool']}) ...", flush=True)
+    oracle, check = prepare(entry)
+    try:
+        # Always start over from the original input.
+        source = entry["dir"] / "work" / ("watch" + entry["extension"])
+        shutil.copy(original_path(entry), source)
+
+        if not is_interesting(check, source):
+            print(
+                f"ERROR: {original_path(entry)} does not reproduce the failure "
+                f"(try `python3 evaluation/run.py --check {entry['id']}`)",
+                file=sys.stderr,
+            )
+            return 1
+
+        command = [
+            "uv", "run", "shrinkray",
+            f"--timeout={entry.get('timeout', 10)}",
+        ]
+        if entry["oracle"]["type"] == "docker":
+            command.append("--input-type=stdin")
+        parallelism = (
+            args.parallelism
+            if args.parallelism is not None
+            else entry.get("parallelism")
+        )
+        if parallelism is not None:
+            command.append(f"--parallelism={parallelism}")
+        command += entry.get("shrinkray_args", [])
+        command += extra
+        command += [str(check), str(source)]
+
+        if args.dry_run:
+            print(shlex.join(command))
+            return 0
+
+        proc = subprocess.run(command, cwd=REPO_ROOT)
+        print(f"\nReduced file left in {source}")
+        print("(watch.py does not update shrinkray_reduced.* or result.json;")
+        print(" use run.py for recorded reductions)")
+        return proc.returncode
+    finally:
+        oracle.teardown()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/notes/core-abstractions.md
+++ b/notes/core-abstractions.md
@@ -106,6 +106,13 @@ ShrinkRay organizes byte passes into tiers:
 2. **great_passes**: Core passes run in a loop until no progress
 3. **ok_passes**: Run when great passes stop making progress
 4. **last_ditch_passes**: Expensive or low-value passes run at the end
+5. **polish_passes**: Very expensive, mostly-normalising passes run only after everything else converges
+
+Scheduling is also adaptive per pass: completed fruitless runs are
+fingerprinted (the pass is skipped until the test case changes), passes
+with a fruitless record run under a small probation budget, and any
+budget-aborted pass is re-run in full before the reduction finishes so
+final results are unaffected. See `notes/reduction-passes.md`.
 
 ## ReductionPump[T]
 

--- a/notes/reduction-passes.md
+++ b/notes/reduction-passes.md
@@ -38,7 +38,27 @@ The `ShrinkRay` reducer organises passes into stages:
 
 1. **initial_cuts**: Fast, high-value passes (comments, hollow, large blocks) with timeout-based cancellation
 2. **great_passes**: Core loop (line and semicolon-split deletion, hollow, lift_braces, debracket) - runs until no progress
-3. **ok_passes**: Run when great_passes plateau (token deletion, smaller blocks, normalisation)
-4. **last_ditch_passes**: Expensive or low-yield passes (byte lowering, brackets)
+3. **ok_passes**: Run when great_passes plateau (smaller blocks, normalisation)
+4. **last_ditch_passes**: Expensive or low-yield passes (token block deletion, brackets)
+5. **polish_passes**: Very expensive, very low-yield passes (short_deletions, byte lowering) that mostly normalise rather than shrink. They only run once every other stage has converged.
 
 Great passes loop until no progress, tracking which passes succeeded to prioritise them on subsequent iterations.
+
+### Adaptive scheduling
+
+`run_pass` adapts to each pass's recent record (all of this was tuned
+against `evaluation/benchmark.py`, which measures interestingness calls on
+a fixed problem suite):
+
+- **Fingerprints**: a pass that ran to completion without making progress
+  is skipped for free until the test case changes. Pass candidate
+  generation is deterministic given the test case (randomness only affects
+  order), so re-running it would be a no-op.
+- **Probation budgets**: a pass whose previous completed run was fruitless
+  gets only `probation_budget` consecutive failed calls on its next run
+  before being abandoned for now.
+- **Targeted verification**: abandoned passes are recorded in
+  `incomplete_passes` and re-run without a budget before the reducer
+  finishes, so the final result is a fixpoint of every pass, exactly as if
+  no budgets existed. Budgets only move work later (usually onto much
+  smaller test cases); they never skip it entirely.

--- a/src/shrinkray/problem.py
+++ b/src/shrinkray/problem.py
@@ -454,6 +454,10 @@ class ReductionProblem[T](ABC):
     work: WorkContext
     # Track current pass stats for real-time updates (set by reducer)
     current_pass_stats: PassStatsProtocol | None = None
+    # Called after every real evaluation of the interestingness test (not
+    # cache hits), letting the reducer observe a running pass's progress
+    # (set by the reducer for the duration of a pass run).
+    pass_call_monitor: Callable[[], None] | None = None
 
     def __attrs_post_init__(self) -> None:
         # Cache of View objects for each Format, to avoid re-parsing
@@ -700,6 +704,8 @@ class BasicReductionProblem(ReductionProblem[T]):
                     await f(test_case)
             else:
                 self.stats.wasted_interesting_calls += 1
+        if self.pass_call_monitor is not None:
+            self.pass_call_monitor()
         return result
 
     @property

--- a/src/shrinkray/reducer.py
+++ b/src/shrinkray/reducer.py
@@ -210,13 +210,11 @@ class ShrinkRay(Reducer[bytes]):
             compose(Split(b"\n"), block_deletion(11, 20)),
             remove_indents,
             remove_whitespace,
-            compose(Tokenize(), block_deletion(1, 20)),
             reduce_integer_literals,
             replace_falsey_with_zero,
             combine_expressions,
             merge_adjacent_strings,
             lexeme_based_deletions,
-            short_deletions,
             normalize_identifiers,
             line_sorter,
         ]
@@ -224,11 +222,13 @@ class ShrinkRay(Reducer[bytes]):
 
     last_ditch_passes: list[ReductionPass[bytes]] = attrs.Factory(
         lambda: [
+            # Fine-grained token block deletion generates a very large
+            # candidate set with a low success rate; benchmarking shows it
+            # is much cheaper run late, on already-reduced test cases.
+            compose(Tokenize(), block_deletion(1, 20)),
             compose(Split(b"\n"), block_deletion(21, 100)),
             replace_space_with_newlines,
             delete_byte_spans,
-            lower_bytes,
-            lower_individual_bytes,
             simplify_brackets,
             standard_substitutions,
             # This is in last ditch because it's probably not useful
@@ -236,6 +236,41 @@ class ShrinkRay(Reducer[bytes]):
             cut_comment_like_things,
         ]
     )
+
+    # Expensive passes with very low success rates, mostly valuable for
+    # normalising the final result rather than shrinking it. They only run
+    # once everything else has converged: benchmarking showed they consumed
+    # a large fraction of all interestingness calls when interleaved with
+    # the productive passes, for almost no reductions.
+    polish_passes: list[ReductionPass[bytes]] = attrs.Factory(
+        lambda: [
+            short_deletions,
+            lower_bytes,
+            lower_individual_bytes,
+        ]
+    )
+
+    # Number of consecutive failed calls after which a pass on probation
+    # (one whose previous completed run made no progress) is abandoned for
+    # now. Abandoned passes are recorded in incomplete_passes and re-run
+    # without a budget before the reducer finishes, so this only affects
+    # when their work happens, not whether it does.
+    probation_budget: int = 25
+
+    # Passes whose previous completed run made no progress. Such a pass
+    # gets only probation_budget consecutive failures on its next run.
+    pass_probation: dict[str, bool] = attrs.Factory(dict)
+
+    # Passes whose most recent run was cut short by the probation budget,
+    # keyed by name. They must be re-run to completion before finishing.
+    incomplete_passes: dict[str, ReductionPass[bytes]] = attrs.Factory(dict)
+
+    # For each pass that ran to completion without making progress, the
+    # test case it ran against. Re-running a pass on an identical test
+    # case is a deterministic no-op (randomness only affects the order in
+    # which candidates are tried, not which candidates are generated), so
+    # such runs are skipped entirely.
+    pass_fingerprints: dict[str, bytes] = attrs.Factory(dict)
 
     def __attrs_post_init__(self) -> None:
         if is_python(self.target.current_test_case):
@@ -278,12 +313,42 @@ class ShrinkRay(Reducer[bytes]):
             else:
                 return f"Running reduction pump {self.current_pump.__name__}"
 
-    async def run_pass(self, rp: ReductionPass[bytes]) -> None:
+    async def run_pass(
+        self, rp: ReductionPass[bytes], *, budgeted: bool = True
+    ) -> None:
         pass_name = rp.__name__
 
         # Skip if pass is disabled
         if self.is_pass_disabled(pass_name):
             return
+
+        problem = self.target
+
+        # A pass that ran to completion without making progress cannot make
+        # progress on an identical test case, so skip it for free.
+        if self.pass_fingerprints.get(pass_name) == problem.current_test_case:
+            return
+
+        use_budget = budgeted and self.pass_probation.get(pass_name, False)
+        scope = trio.CancelScope()
+        last_seen = problem.current_test_case
+        consecutive_failures = 0
+        budget_exhausted = False
+        made_progress = False
+
+        def monitor() -> None:
+            nonlocal last_seen, consecutive_failures, budget_exhausted
+            nonlocal made_progress
+            current = problem.current_test_case
+            if current is not last_seen:
+                last_seen = current
+                made_progress = True
+                consecutive_failures = 0
+            else:
+                consecutive_failures += 1
+                if use_budget and consecutive_failures > self.probation_budget:
+                    budget_exhausted = True
+                    scope.cancel()
 
         try:
             assert self.current_reduction_pass is None
@@ -296,20 +361,37 @@ class ShrinkRay(Reducer[bytes]):
             stats_entry.run_count += 1
 
             # Set current pass stats on the problem for real-time updates
-            self.target.current_pass_stats = stats_entry
+            problem.current_pass_stats = stats_entry
+            problem.pass_call_monitor = monitor
 
             # Run the pass with a cancel scope that can be externally cancelled
-            with trio.CancelScope() as scope:
+            with scope:
                 self._current_pass_scope = scope
                 await rp(self.target)
 
-            # If the pass was cancelled/skipped, mark that passes were skipped
-            if scope.cancelled_caught:
+            if budget_exhausted:
+                # The pass was abandoned by its probation budget. It still
+                # has untried candidates, so it must be re-run before the
+                # reduction can finish.
+                self.incomplete_passes[pass_name] = rp
+                if made_progress:
+                    self.pass_probation[pass_name] = False
+            elif scope.cancelled_caught:
+                # The pass was skipped externally; mark that passes were
+                # skipped so the main loop runs it again later.
                 self._passes_were_skipped = True
+            else:
+                self.incomplete_passes.pop(pass_name, None)
+                self.pass_probation[pass_name] = not made_progress
+                if made_progress:
+                    self.pass_fingerprints.pop(pass_name, None)
+                else:
+                    self.pass_fingerprints[pass_name] = problem.current_test_case
 
         finally:
             self.current_reduction_pass = None
-            self.target.current_pass_stats = None
+            problem.current_pass_stats = None
+            problem.pass_call_monitor = None
             self._current_pass_scope = None
             self._skip_requested = False
 
@@ -443,7 +525,6 @@ class ShrinkRay(Reducer[bytes]):
         if await self.target.is_interesting(b""):
             return
 
-        prev = 0
         for c in [0, 1, ord(b"\n"), ord(b"0"), ord(b"z"), 255]:
             if await self.target.is_interesting(bytes([c])):
                 await self.__minimize_single_byte(c)
@@ -461,11 +542,26 @@ class ShrinkRay(Reducer[bytes]):
                 continue
             for pump in self.pumps:
                 await self.pump(pump)
-            if self.target.current_test_case == prev:
-                # Only terminate if no passes were skipped
-                # If passes were skipped, we need another full run to be sure
-                if not self._passes_were_skipped:
-                    break
+            if self.target.current_test_case != prev:
+                continue
+            # Only once everything else has converged do the expensive,
+            # rarely-productive polish passes run.
+            for rp in self.polish_passes:
+                await self.run_pass(rp)
+            if self.target.current_test_case != prev:
+                continue
+            # Passes abandoned by a probation budget may have missed
+            # reductions. Re-run them without a budget before concluding,
+            # so the final result is a fixpoint of every pass.
+            if self.incomplete_passes:
+                for name in sorted(self.incomplete_passes):
+                    await self.run_pass(self.incomplete_passes[name], budgeted=False)
+                if self.target.current_test_case != prev:
+                    continue
+            # Only terminate if no passes were skipped
+            # If passes were skipped, we need another full run to be sure
+            if not self._passes_were_skipped:
+                break
 
 
 class UpdateKeys(Patches[dict[str, bytes], dict[str, bytes]]):

--- a/tests/test_reducer.py
+++ b/tests/test_reducer.py
@@ -1787,3 +1787,379 @@ async def test_reducer_continues_when_passes_skipped():
 
     # Should have run at least twice (once skipped, once full)
     assert run_count[0] >= 2
+
+
+# === Adaptive pass scheduling tests ===
+
+
+async def test_pass_call_monitor_called_after_each_real_evaluation():
+    """The monitor fires once per real evaluation: not for cache hits or
+    for candidates equal to the current test case."""
+
+    async def is_interesting(x):
+        return x == b"hello world"
+
+    problem = BasicReductionProblem(
+        initial=b"hello world",
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+    )
+
+    monitor_calls = [0]
+
+    def monitor():
+        monitor_calls[0] += 1
+
+    problem.pass_call_monitor = monitor
+
+    await problem.is_interesting(b"x")
+    assert monitor_calls[0] == 1
+
+    # Cache hit: no new evaluation, no monitor call.
+    await problem.is_interesting(b"x")
+    assert monitor_calls[0] == 1
+
+    # Current test case: answered without evaluation.
+    await problem.is_interesting(b"hello world")
+    assert monitor_calls[0] == 1
+
+
+async def test_run_pass_skips_fruitless_pass_on_unchanged_input():
+    """A pass that completed without progress is not re-run until the
+    test case changes: re-running it is a deterministic no-op."""
+
+    async def is_interesting(x):
+        return x in (b"aaaa", b"aa")
+
+    problem = BasicReductionProblem(
+        initial=b"aaaa",
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+    )
+    reducer = ShrinkRay(target=problem)
+
+    invocations = [0]
+
+    async def fruitless(p):
+        invocations[0] += 1
+        await p.is_interesting(b"zzzz")
+
+    fruitless.__name__ = "fruitless"
+
+    await reducer.run_pass(fruitless)
+    assert invocations[0] == 1
+    assert reducer.pass_fingerprints["fruitless"] == b"aaaa"
+
+    await reducer.run_pass(fruitless)
+    assert invocations[0] == 1
+
+    # After the test case changes the pass runs again.
+    assert await problem.is_interesting(b"aa")
+    await reducer.run_pass(fruitless)
+    assert invocations[0] == 2
+
+
+async def test_run_pass_clears_fingerprint_when_pass_makes_progress():
+    async def is_interesting(x):
+        return x in (b"aaaa", b"aaa", b"aa")
+
+    problem = BasicReductionProblem(
+        initial=b"aaaa",
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+    )
+    reducer = ShrinkRay(target=problem)
+
+    async def sometimes_reduces(p):
+        if p.current_test_case == b"aaa":
+            await p.is_interesting(b"aa")
+        else:
+            await p.is_interesting(b"zzzz")
+
+    sometimes_reduces.__name__ = "sometimes_reduces"
+
+    await reducer.run_pass(sometimes_reduces)
+    assert "sometimes_reduces" in reducer.pass_fingerprints
+    assert reducer.pass_probation["sometimes_reduces"]
+
+    assert await problem.is_interesting(b"aaa")
+    await reducer.run_pass(sometimes_reduces)
+    assert "sometimes_reduces" not in reducer.pass_fingerprints
+    assert not reducer.pass_probation["sometimes_reduces"]
+
+
+async def test_run_pass_probation_budget_aborts_repeat_fruitless_run():
+    """After a fruitless run, a pass gets only a small call budget on its
+    next run. Exceeding it aborts the pass and records it as incomplete,
+    without counting as a user skip."""
+
+    async def is_interesting(x):
+        return x in (b"aaaa", b"aa")
+
+    problem = BasicReductionProblem(
+        initial=b"aaaa",
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+    )
+    reducer = ShrinkRay(target=problem)
+    reducer.probation_budget = 5
+
+    attempts = [0]
+    counter = [0]
+
+    async def junk_generator(p):
+        for _ in range(50):
+            attempts[0] += 1
+            counter[0] += 1
+            await p.is_interesting(b"z%d" % counter[0])
+
+    junk_generator.__name__ = "junk_generator"
+
+    # First run is never budgeted: all 50 candidates are tried.
+    await reducer.run_pass(junk_generator)
+    assert attempts[0] == 50
+    assert reducer.pass_probation["junk_generator"]
+
+    assert await problem.is_interesting(b"aa")
+
+    # Second run is on probation and gets aborted after the budget.
+    await reducer.run_pass(junk_generator)
+    assert attempts[0] - 50 <= reducer.probation_budget + 2
+    assert "junk_generator" in reducer.incomplete_passes
+    assert not reducer._passes_were_skipped
+
+
+async def test_run_pass_probation_cleared_when_aborted_run_made_progress():
+    async def is_interesting(x):
+        return x in (b"aaaaaa", b"aaaa", b"aa")
+
+    problem = BasicReductionProblem(
+        initial=b"aaaaaa",
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+    )
+    reducer = ShrinkRay(target=problem)
+    reducer.probation_budget = 3
+
+    counter = [0]
+
+    async def reduces_then_churns(p):
+        if p.current_test_case == b"aaaa":
+            await p.is_interesting(b"aa")
+        for _ in range(20):
+            counter[0] += 1
+            await p.is_interesting(b"z%d" % counter[0])
+
+    reduces_then_churns.__name__ = "reduces_then_churns"
+
+    await reducer.run_pass(reduces_then_churns)
+    assert reducer.pass_probation["reduces_then_churns"]
+
+    assert await problem.is_interesting(b"aaaa")
+
+    await reducer.run_pass(reduces_then_churns)
+    assert "reduces_then_churns" in reducer.incomplete_passes
+    # It reduced during the aborted run, so it comes off probation.
+    assert not reducer.pass_probation["reduces_then_churns"]
+
+
+async def test_run_verifies_aborted_passes_before_finishing():
+    """A reduction hiding beyond the probation budget is still found:
+    incomplete passes are re-run without a budget before termination."""
+
+    A, B1, B2, C = b"aaaaaaaa", b"aaaaaa", b"aaaa", b"aa"
+
+    async def is_interesting(x):
+        return x in (A, B1, B2, C)
+
+    problem = BasicReductionProblem(
+        initial=A,
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+    )
+    reducer = ShrinkRay(target=problem)
+    reducer.probation_budget = 3
+    counter = [0]
+
+    async def stepper(p):
+        if p.current_test_case == A:
+            await p.is_interesting(B1)
+        elif p.current_test_case == B1:
+            await p.is_interesting(B2)
+
+    stepper.__name__ = "stepper"
+
+    async def late_bloomer(p):
+        junk_count = 10 if p.current_test_case == B2 else 3
+        for _ in range(junk_count):
+            counter[0] += 1
+            await p.is_interesting(b"z%d" % counter[0])
+        if p.current_test_case == B2:
+            await p.is_interesting(C)
+
+    late_bloomer.__name__ = "late_bloomer"
+
+    reducer.initial_cuts = []
+    reducer.great_passes = [stepper, late_bloomer]
+    reducer.ok_passes = []
+    reducer.last_ditch_passes = []
+    reducer.polish_passes = []
+
+    await reducer.run()
+
+    assert problem.current_test_case == C
+    assert not reducer.incomplete_passes
+
+
+async def test_run_terminates_when_verification_finds_nothing():
+    A, B, C = b"aaaaaaaa", b"aaaaaa", b"aaaa"
+
+    async def is_interesting(x):
+        return x in (A, B, C)
+
+    problem = BasicReductionProblem(
+        initial=A,
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+    )
+    reducer = ShrinkRay(target=problem)
+    reducer.probation_budget = 3
+    counter = [0]
+
+    async def stepper(p):
+        if p.current_test_case == A:
+            await p.is_interesting(B)
+        elif p.current_test_case == B:
+            await p.is_interesting(C)
+
+    stepper.__name__ = "stepper"
+
+    async def churner(p):
+        for _ in range(10):
+            counter[0] += 1
+            await p.is_interesting(b"z%d" % counter[0])
+
+    churner.__name__ = "churner"
+
+    reducer.initial_cuts = []
+    reducer.great_passes = [stepper, churner]
+    reducer.ok_passes = []
+    reducer.last_ditch_passes = []
+    reducer.polish_passes = []
+
+    await reducer.run()
+
+    # churner went on probation after its first fruitless run, was
+    # budget-aborted on a later input, and its verification re-run found
+    # nothing: the reduction still terminates with a clean slate.
+    assert problem.current_test_case == C
+    assert not reducer.incomplete_passes
+
+
+async def test_run_repeats_cycle_after_user_skip():
+    """A user-skipped pass forces another full cycle so it gets re-run."""
+
+    async def is_interesting(x):
+        return x == b"aaaa"
+
+    problem = BasicReductionProblem(
+        initial=b"aaaa",
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+    )
+    reducer = ShrinkRay(target=problem)
+
+    invocations = [0]
+
+    async def self_skipping(p):
+        invocations[0] += 1
+        if invocations[0] == 1:
+            reducer.skip_current_pass()
+            await p.is_interesting(b"zzzz")
+
+    self_skipping.__name__ = "self_skipping"
+
+    reducer.initial_cuts = []
+    reducer.great_passes = [self_skipping]
+    reducer.ok_passes = []
+    reducer.last_ditch_passes = []
+    reducer.polish_passes = []
+
+    await reducer.run()
+
+    # First invocation was skipped, so the loop ran the pass again.
+    assert invocations[0] == 2
+
+
+async def test_polish_passes_run_only_after_other_passes_stall():
+    A, B, C = b"aaaaaaaa", b"aaaa", b"aa"
+
+    async def is_interesting(x):
+        return x in (A, B, C)
+
+    problem = BasicReductionProblem(
+        initial=A,
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+    )
+    reducer = ShrinkRay(target=problem)
+
+    events = []
+
+    async def great(p):
+        events.append("great")
+        if p.current_test_case == A:
+            await p.is_interesting(B)
+
+    great.__name__ = "great"
+
+    async def polish(p):
+        events.append("polish")
+        if p.current_test_case == B:
+            await p.is_interesting(C)
+
+    polish.__name__ = "polish"
+
+    reducer.initial_cuts = []
+    reducer.great_passes = [great]
+    reducer.ok_passes = []
+    reducer.last_ditch_passes = []
+    reducer.polish_passes = [polish]
+
+    await reducer.run()
+
+    assert problem.current_test_case == C
+    # Polish only starts once the other passes have stalled.
+    assert "polish" in events
+    first_polish = events.index("polish")
+    assert "great" in events[:first_polish]
+
+
+def test_default_tiers_reflect_measured_pass_value():
+    """Guards the benchmark-driven tier assignment: expensive low-yield
+    passes are deferred to the polish tier, and fine-grained token block
+    deletion runs as a last-ditch pass rather than an ok pass."""
+
+    async def is_interesting(x):
+        return True
+
+    problem = BasicReductionProblem(
+        initial=b"hello world",
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+    )
+    reducer = ShrinkRay(target=problem)
+
+    polish_names = {p.__name__ for p in reducer.polish_passes}
+    ok_names = {p.__name__ for p in reducer.ok_passes}
+    last_ditch_names = {p.__name__ for p in reducer.last_ditch_passes}
+
+    assert polish_names == {
+        "short_deletions",
+        "lower_bytes",
+        "lower_individual_bytes",
+    }
+    assert not (polish_names & ok_names)
+    assert not (polish_names & last_ditch_names)
+    assert "tokenize/block_deletion(1, 20)" in last_ditch_names
+    assert "tokenize/block_deletion(1, 20)" not in ok_names


### PR DESCRIPTION
<details>
<summary>AI-generated description</summary>

This expands `evaluation/benchmark.py` into a proper measurement harness for scheduling work — nine problems (three existing synthetics, a syntax-constrained synthetic, and five derived from corpus entries with cheap in-process predicates), progress metrics (calls to 90%/99% of the eventual reduction, tail calls after the last reduction), per-pass stats, and a committed baseline to diff against. Call counts are reproducible to within a couple of calls, so a change of a few percent is real signal regardless of machine load.

The scheduler changes it motivated, all measured against that harness:

- A new **polish tier**: `short_deletions` and the byte-lowering passes were ~29% of all calls on the suite for almost no reductions when interleaved mid-reduction; they now run only after everything else converges.
- `tokenize/block_deletion(1, 20)` moves to last-ditch, so its huge candidate set scans already-reduced input.
- **Fingerprints**: a pass that completes without progress is skipped for free until the test case changes (candidate generation is deterministic given the test case).
- **Probation budgets with targeted verification**: a pass whose last completed run was fruitless gets 25 consecutive failures before being set aside, and anything set aside is re-run in full before termination — so the final result is still a fixpoint of every pass, and all nine benchmark finals are byte-identical to before.

Net effect: 5.5% fewer interestingness calls overall, with much better front-loading (calls to reach 99% of the final reduction: pylint corpus entry 1170 → 397, mypy 847 → 667). More aggressive schedules measured up to 83% savings but degraded final quality, so this lands the quality-preserving subset; the experiments point at candidate-set sizes (not ordering) as the next big lever.

The two `test_failure_performance` wall-clock tests fail locally under heavy machine load, with call counts verified identical to main (335 before and after).
</details>