### PR TITLE
Fix flaky test_can_reduce_a_directory by pinning parallelism to 1

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -91,6 +91,10 @@ except AssertionError:
         ]
     )
 
+    # With parallelism > 1, speculative execution races can land the reducer
+    # in different final fixed points (e.g. deleting a.py entirely and
+    # reducing c.py to "assert 0"), so the exact-output assertions below need
+    # a deterministic single-threaded reduction.
     if in_place:
         subprocess.check_call(
             [
@@ -102,6 +106,7 @@ except AssertionError:
                 str(target),
                 "--ui=basic",
                 "--no-history",
+                "--parallelism=1",
             ],
         )
     else:
@@ -114,6 +119,7 @@ except AssertionError:
                 str(target),
                 "--ui=basic",
                 "--no-history",
+                "--parallelism=1",
             ],
         )
 


### PR DESCRIPTION
The slow-tests job on main failed in `test_can_reduce_a_directory[False]` ([run 28744730124](https://github.com/DRMacIver/shrinkray/actions/runs/28744730124/job/85233577398)): the test asserts the exact final contents of the reduced directory, but with parallelism enabled speculative execution races mean the reducer can land in different final fixed points. Sometimes it finds the expected result (`a.py` kept as `x=0`, `c.py` as `from a import x` / `assert x`), and sometimes a strictly smaller one where it deletes `a.py` entirely and reduces `c.py` to just `assert 0` — at which point the `assert a.exists()` check fails. Locally on current main the smaller outcome is actually the common one.

This pins the test's reduction to `--parallelism=1`, which makes it take a deterministic path and reliably converge to the expected result (verified with several consecutive runs of both variants). That keeps the exact-output assertions meaningful; each variant takes ~45s instead of ~15s, which seems fine for a test already marked slow.

<details><summary>Notes</summary>

Tests-only change, so no RELEASE.md is needed. The nondeterminism itself isn't new — which fixed point the parallel reducer reaches has always been timing-dependent — but the dominant outcome appears to have shifted with the recent adaptive scheduling change, which is why this only started failing now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>