### PR TITLE
Add grammar-aware reduction passes via tree-sitter

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+- Shrink Ray now has grammar-aware reduction passes for any language with a
+  tree-sitter grammar (Go, Rust, JavaScript, Java, Haskell, and many others,
+  selected by file extension). These delete whole syntactic constructs, lift
+  nested structure into parent positions, replace constructs with smaller
+  same-kind ones found elsewhere in the file, and delete dead declarations
+  together with the imports only they used — the latter unblocks reduction in
+  languages like Go whose compilers reject unused imports.

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -4,7 +4,8 @@ A corpus of **real bugs in real tools** — inputs that make a specific
 pinned version of a compiler, formatter, linter, JSON parser, or SAT
 solver crash — used to evaluate shrink ray's reduction quality on
 realistic material across the formats it supports (C/C++, Python, JSON,
-DIMACS CNF), and to compare it against other reducers.
+DIMACS CNF, and tree-sitter-grammar languages like Go, Rust, and
+JavaScript), and to compare it against other reducers.
 
 Each entry is a plausible, pre-reduction-sized input with a genuine bug
 trigger buried inside realistic scaffolding (application-shaped code,

--- a/evaluation/RESULTS.md
+++ b/evaluation/RESULTS.md
@@ -21,7 +21,7 @@ each removed.
 | gcc49-pr64382-genlambda-template-member | cpp | gcc (gcc:4.9) | 879 | 128 | 119 | 85.4% | — |
 | gcc49-pr77739-variadic-auto-lambda | cpp | gcc (gcc:4.9) | 1004 | 166 | 160 | 83.5% | — |
 | gcc49-udlit-char-pack-template | cpp | gcc (gcc:4.9) | 834 | 126 | 122 | 84.9% | — |
-| go11810-generic-untyped-bool-ice | go | go 1.18.10 (gc) | 2288 | 220 | 181 | 90.4% | 936.6 |
+| go11810-generic-untyped-bool-ice | go | go 1.18.10 (gc) | 2288 | 220 | 181 | 90.4% | 906.2 |
 | jq-1.5-cve-2016-4074-deep-nest-segfault | json | jq 1.5 | 120426 | — | — | — | — |
 | kissat402-decide-disconnected | cnf | kissat 4.0.2 | 4295 | 536 | 349 | 87.5% | 918.2 |
 | minisat-dimacs-int-overflow | cnf | minisat 2.2 (git 37dc6c6, ASan) | 2326 | 14 | 12 | 99.4% | 1555.9 |
@@ -29,7 +29,7 @@ each removed.
 | pylint-2.17.4-duplicate-bases-mro-crash | python | pylint 2.17.4 (astroid 2.15.5) | 2403 | 51 | 34 | 97.9% | 109.0 |
 | python-rapidjson-10-deep-nest-segfault | json | python-rapidjson 1.0 | 200426 | — | — | — | — |
 | ruff-0.0.277-isort-skip-block-panic | python | ruff 0.0.277 | 2774 | 56 | 38 | 98.0% | 10.0 |
-| rustc-1941-gce-braced-const-arg-ice | rust | rustc 1.94.1 | 2480 | 141 | 111 | 94.3% | 76.9 |
+| rustc-1941-gce-braced-const-arg-ice | rust | rustc 1.94.1 | 2480 | 141 | 111 | 94.3% | 61.0 |
 | shrinkray-json-deep-nesting | json | python json (deep-nesting regression) | 1495 | 608 | 602 | 59.3% | 55.8 |
 | shrinkray-libcst-deep-nesting | python | libcst 1.8.6 (deep-nesting regression) | 4378 | 800 | 800 | 81.7% | 1125.9 |
 | splr0172-eliminate-assert | cnf | splr 0.17.2 (debug-assertions) | 3148 | 329 | 209 | 89.5% | — |

--- a/evaluation/RESULTS.md
+++ b/evaluation/RESULTS.md
@@ -21,16 +21,19 @@ each removed.
 | gcc49-pr64382-genlambda-template-member | cpp | gcc (gcc:4.9) | 879 | 128 | 119 | 85.4% | — |
 | gcc49-pr77739-variadic-auto-lambda | cpp | gcc (gcc:4.9) | 1004 | 166 | 160 | 83.5% | — |
 | gcc49-udlit-char-pack-template | cpp | gcc (gcc:4.9) | 834 | 126 | 122 | 84.9% | — |
+| go11810-generic-untyped-bool-ice | go | go 1.18.10 (gc) | 2288 | 220 | 181 | 90.4% | 936.6 |
 | jq-1.5-cve-2016-4074-deep-nest-segfault | json | jq 1.5 | 120426 | — | — | — | — |
 | kissat402-decide-disconnected | cnf | kissat 4.0.2 | 4295 | 536 | 349 | 87.5% | 918.2 |
 | minisat-dimacs-int-overflow | cnf | minisat 2.2 (git 37dc6c6, ASan) | 2326 | 14 | 12 | 99.4% | 1555.9 |
 | mypy-0.942-match-union-tuple-crash | python | mypy 0.942 | 2537 | 133 | 77 | 94.8% | 477.7 |
 | pylint-2.17.4-duplicate-bases-mro-crash | python | pylint 2.17.4 (astroid 2.15.5) | 2403 | 51 | 34 | 97.9% | 109.0 |
 | python-rapidjson-10-deep-nest-segfault | json | python-rapidjson 1.0 | 200426 | — | — | — | — |
-| ruff-0.0.277-isort-skip-block-panic | python | ruff 0.0.277 | 2774 | 55 | 37 | 98.0% | 20.3 |
+| ruff-0.0.277-isort-skip-block-panic | python | ruff 0.0.277 | 2774 | 56 | 38 | 98.0% | 10.0 |
+| rustc-1941-gce-braced-const-arg-ice | rust | rustc 1.94.1 | 2480 | 141 | 111 | 94.3% | 76.9 |
 | shrinkray-json-deep-nesting | json | python json (deep-nesting regression) | 1495 | 608 | 602 | 59.3% | 55.8 |
 | shrinkray-libcst-deep-nesting | python | libcst 1.8.6 (deep-nesting regression) | 4378 | 800 | 800 | 81.7% | 1125.9 |
 | splr0172-eliminate-assert | cnf | splr 0.17.2 (debug-assertions) | 3148 | 329 | 209 | 89.5% | — |
+| terser-5151-forof-empty-pattern-crash | javascript | terser 5.15.1 | 2945 | 24 | 22 | 99.2% | 44.3 |
 | ujson-510-indent-buffer-overflow | json | ujson 5.1.0 | 826 | 110 | 92 | 86.7% | 102.1 |
 
 ### c-reduce comparison (C/C++ entries)
@@ -66,6 +69,57 @@ result stays large and the reduction is slow, so full reduced outputs are
 not committed for those two; they are kept as reproduce-and-don't-crash
 entries. The shallow ujson entry (a buffer overflow that triggers at
 modest depth) is the representative small-JSON reduction.
+
+## The tree-sitter entries (Go, Rust, JavaScript)
+
+The `go11810`, `rustc-1941`, and `terser-5151` entries were added to
+evaluate the tree-sitter suggestion in issue #59: they are real crash
+bugs in languages shrink ray had **no** dedicated passes for, all
+reproducible natively with fast oracles. The method followed the
+issue's suggestion: reduce with the byte-level passes only, inspect
+what was left, prototype grammar-aware candidates starting from that
+converged output, then integrate what earned its keep as the passes in
+`src/shrinkray/passes/treesitter.py`.
+
+Baseline (pre-tree-sitter) vs current, same oracles and settings:
+
+| Entry | Baseline | With tree-sitter passes | Baseline seconds | Seconds |
+|-------|---------:|------------------------:|-----------------:|--------:|
+| go11810-generic-untyped-bool-ice | 317 | 220 | 1828 | 937 |
+| rustc-1941-gce-braced-const-arg-ice | 185 | 141 | 165 | 77 |
+| terser-5151-forof-empty-pattern-crash | 24 | 24 | 60 | 44 |
+
+Observations:
+
+- **Coupled deletions were the real gap, not deletion as such.** The
+  baseline Go result kept a dead function, `sort.Strings`/`strings.Join`
+  calls, and three imports: Go hard-errors on unused imports, so the
+  dead function and the imports only it used could only be deleted
+  *together*, and no byte-level pass can propose that jointly. The
+  `delete_orphaned_declarations` pass (delete a node plus declarations
+  left textually unreferenced, cascading) expresses exactly this and
+  accounts for most of the Go improvement.
+- **Grammar passes alone are not competitive.** A greedy reducer using
+  only the tree-sitter candidates reached 368/247/86 bytes from the
+  originals — worse than the byte-level baseline on every entry. The
+  value is complementarity: grammar passes unblock structural steps,
+  byte-level passes clean up (whitespace, identifiers, literals). This
+  is why they are ordinary passes inside the pipeline rather than a
+  separate mode.
+- **They make reduction faster, not slower.** Every entry converged in
+  roughly half the wall-clock time: structure-sized cuts land early
+  and shrink the input for every later pass. The one Python entry
+  re-run as a regression check (`ruff`) was byte-for-byte comparable
+  (56 vs 55 bytes, run-to-run noise) in half the time.
+- **Remaining floor.** The Go result still keeps `type a`, a slice
+  append loop, and the `strings` import because removing the final
+  `strings.Join` call needs a four-way coupled edit (delete the return
+  statement + the function's result type + the then-unused local + the
+  import). Reaching it generically would need candidates driven by
+  more than textual reference-counting; noted as possible future work.
+- tree-sitter's error tolerance matters: mid-reduction states are
+  often syntactically invalid (the converged Rust output is not valid
+  Rust), and the passes keep operating on the parseable parts.
 
 ## C/C++ entries: shrink ray vs c-reduce
 

--- a/evaluation/corpus/go11810-generic-untyped-bool-ice/meta.json
+++ b/evaluation/corpus/go11810-generic-untyped-bool-ice/meta.json
@@ -1,0 +1,21 @@
+{
+  "id": "go11810-generic-untyped-bool-ice",
+  "format": "go",
+  "tool": "go 1.18.10 (gc)",
+  "extension": ".go",
+  "bug_url": "https://github.com/golang/go/issues/54537",
+  "symptom": "The go1.18 compiler crashes with 'internal compiler error: expression has untyped type' when a string comparison (an untyped bool expression) is assigned to a variable of a generic type parameter constrained by ~bool. Fixed during go1.20 development.",
+  "oracle": {
+    "type": "command",
+    "setup": "setup.sh",
+    "command": ["go", "build", "-o", "/dev/null", "{file}"],
+    "env": {
+      "GOTOOLCHAIN": "go1.18.10"
+    }
+  },
+  "interesting": {
+    "output_contains": "internal compiler error: expression has untyped type",
+    "exit_code": 2
+  },
+  "timeout": 10
+}

--- a/evaluation/corpus/go11810-generic-untyped-bool-ice/original.go
+++ b/evaluation/corpus/go11810-generic-untyped-bool-ice/original.go
@@ -1,0 +1,101 @@
+// Command healthwatch polls a set of service endpoints and reports
+// which ones have converged to the "ready" state. Predicate results are
+// generic over bool-like types so callers can plug in their own flag
+// types with String() methods.
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type ServiceState struct {
+	Name     string
+	State    string
+	Restarts int
+}
+
+// StrictFlag is a defined bool used by callers that want method sets on
+// their readiness flags.
+type StrictFlag bool
+
+func (f StrictFlag) String() string {
+	if f {
+		return "ready"
+	}
+	return "not-ready"
+}
+
+func splitCSV(line string) []string {
+	parts := strings.Split(line, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+func parseState(line string) (ServiceState, error) {
+	fields := splitCSV(line)
+	if len(fields) < 2 {
+		return ServiceState{}, fmt.Errorf("malformed state line: %q", line)
+	}
+	state := ServiceState{Name: fields[0], State: fields[1]}
+	if len(fields) > 2 {
+		if _, err := fmt.Sscanf(fields[2], "%d", &state.Restarts); err != nil {
+			return ServiceState{}, fmt.Errorf("bad restart count in %q", line)
+		}
+	}
+	return state, nil
+}
+
+// isReady reports readiness as any bool-like flag type.
+func isReady[B ~bool](state string) B {
+	var ready B = state == "ready"
+	return ready
+}
+
+func summarize(states []ServiceState) string {
+	names := make([]string, 0, len(states))
+	for _, s := range states {
+		if isReady[StrictFlag](s.State) {
+			names = append(names, s.Name)
+		}
+	}
+	sort.Strings(names)
+	return strings.Join(names, ",")
+}
+
+func worstRestarts(states []ServiceState) int {
+	worst := 0
+	for _, s := range states {
+		if s.Restarts > worst {
+			worst = s.Restarts
+		}
+	}
+	return worst
+}
+
+func main() {
+	input := []string{
+		"gateway, ready, 0",
+		"scheduler, degraded, 3",
+		"store, ready, 1",
+	}
+	states := make([]ServiceState, 0, len(input))
+	for _, line := range input {
+		s, err := parseState(line)
+		if err != nil {
+			fmt.Println("skipping:", err)
+			continue
+		}
+		states = append(states, s)
+	}
+	fmt.Println("ready:", summarize(states))
+	fmt.Println("worst restart count:", worstRestarts(states))
+	fmt.Println("gateway flag:", isReady[StrictFlag]("ready"))
+}

--- a/evaluation/corpus/go11810-generic-untyped-bool-ice/result.json
+++ b/evaluation/corpus/go11810-generic-untyped-bool-ice/result.json
@@ -1,0 +1,10 @@
+{
+  "id": "go11810-generic-untyped-bool-ice",
+  "status": "ok",
+  "original_bytes": 2288,
+  "reduced_bytes": 220,
+  "original_nows_bytes": 1845,
+  "reduced_nows_bytes": 181,
+  "seconds": 936.6,
+  "ratio": 90.4
+}

--- a/evaluation/corpus/go11810-generic-untyped-bool-ice/result.json
+++ b/evaluation/corpus/go11810-generic-untyped-bool-ice/result.json
@@ -5,6 +5,6 @@
   "reduced_bytes": 220,
   "original_nows_bytes": 1845,
   "reduced_nows_bytes": 181,
-  "seconds": 936.6,
+  "seconds": 906.2,
   "ratio": 90.4
 }

--- a/evaluation/corpus/go11810-generic-untyped-bool-ice/setup.sh
+++ b/evaluation/corpus/go11810-generic-untyped-bool-ice/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -eu
+# Pre-download the pinned toolchain into the module cache so the first
+# oracle call doesn't pay the download; a no-op once cached.
+GOTOOLCHAIN=go1.18.10 go version

--- a/evaluation/corpus/go11810-generic-untyped-bool-ice/shrinkray_reduced.go
+++ b/evaluation/corpus/go11810-generic-untyped-bool-ice/shrinkray_reduced.go
@@ -1,0 +1,16 @@
+package b
+import"strings"
+type a struct {
+a string
+}
+type d bool
+func b[c~bool](a string)c {
+var d c = a<""
+return d
+}
+func c(a[]a)string {
+c:=make([]string, 0)
+for _, c:=range a {
+b[d](c.a)}
+return strings.Join(c, "")
+}

--- a/evaluation/corpus/go11810-generic-untyped-bool-ice/shrinkray_reduced.go
+++ b/evaluation/corpus/go11810-generic-untyped-bool-ice/shrinkray_reduced.go
@@ -4,13 +4,12 @@ type a struct {
 a string
 }
 type d bool
-func b[c~bool](a string)c {
-var d c = a<""
+func b[c~bool](a string)c {var d c = a<""
 return d
 }
-func c(a[]a)string {
-c:=make([]string, 0)
-for _, c:=range a {
+func c(a[]a)string{
+c:= make([]string, 0)
+for _, c:= range a {
 b[d](c.a)}
 return strings.Join(c, "")
 }

--- a/evaluation/corpus/ruff-0.0.277-isort-skip-block-panic/result.json
+++ b/evaluation/corpus/ruff-0.0.277-isort-skip-block-panic/result.json
@@ -2,9 +2,9 @@
   "id": "ruff-0.0.277-isort-skip-block-panic",
   "status": "ok",
   "original_bytes": 2774,
-  "reduced_bytes": 55,
+  "reduced_bytes": 56,
   "original_nows_bytes": 2137,
-  "reduced_nows_bytes": 37,
-  "seconds": 20.3,
+  "reduced_nows_bytes": 38,
+  "seconds": 10.0,
   "ratio": 98.0
 }

--- a/evaluation/corpus/ruff-0.0.277-isort-skip-block-panic/shrinkray_reduced.py
+++ b/evaluation/corpus/ruff-0.0.277-isort-skip-block-panic/shrinkray_reduced.py
@@ -1,4 +1,4 @@
 try:  # isort:skip
-    0  # isort:skip
+    ()  # isort:skip
 except:
     ...

--- a/evaluation/corpus/rustc-1941-gce-braced-const-arg-ice/meta.json
+++ b/evaluation/corpus/rustc-1941-gce-braced-const-arg-ice/meta.json
@@ -1,0 +1,31 @@
+{
+  "id": "rustc-1941-gce-braced-const-arg-ice",
+  "format": "rust",
+  "tool": "rustc 1.94.1",
+  "extension": ".rs",
+  "bug_url": "https://github.com/rust-lang/rust/issues/157938",
+  "symptom": "rustc 1.94.1 (and current nightly) panics with 'var types encountered in structurally_relate_consts: ?1c ?1c' when, under generic_const_exprs, a trait is implemented both generically (with a where clause) and for a braced block const argument ('Trait<{ { N } }>') on the same type.",
+  "oracle": {
+    "type": "command",
+    "setup": "setup.sh",
+    "command": [
+      "rustc",
+      "+1.94.1",
+      "--edition",
+      "2021",
+      "--crate-type",
+      "lib",
+      "{file}",
+      "-o",
+      "/dev/null"
+    ],
+    "env": {
+      "RUSTC_ICE": "0"
+    }
+  },
+  "interesting": {
+    "output_contains": "var types encountered in structurally_relate_consts",
+    "exit_code": 101
+  },
+  "timeout": 10
+}

--- a/evaluation/corpus/rustc-1941-gce-braced-const-arg-ice/original.rs
+++ b/evaluation/corpus/rustc-1941-gce-braced-const-arg-ice/original.rs
@@ -1,0 +1,100 @@
+//! Fixed-capacity frame buffers for the wire protocol, sized at compile
+//! time via const generics. Experimental: relies on `generic_const_exprs`
+//! so capacity arithmetic can appear in bounds.
+
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+pub const HEADER_BYTES: usize = 12;
+pub const MAX_FRAME: usize = 4096;
+
+/// A frame header as read off the wire.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Header {
+    pub version: u8,
+    pub flags: u8,
+    pub length: u16,
+}
+
+impl Header {
+    pub fn wire_size(&self) -> usize {
+        HEADER_BYTES
+    }
+
+    pub fn is_control(&self) -> bool {
+        self.flags & 0x80 != 0
+    }
+}
+
+/// Marker for payload sizes the peer advertises support for.
+pub trait CapacityHint<const N: usize> {}
+
+impl<const N: usize> CapacityHint<N> for Header {}
+
+/// Types that can reserve `N` bytes of frame space ahead of encoding.
+pub trait Reservable<const N: usize> {}
+
+impl<const N: usize> Reservable<N> for Header where Header: CapacityHint<N> {}
+
+// Blanket coverage for capacities produced by the framing macros; the
+// nested block is what the macro expansion leaves behind.
+impl<const N: usize> Reservable<{ { N } }> for Header {}
+
+/// A compile-time sized buffer holding one frame plus its header.
+pub struct FrameBuf<const N: usize>
+where
+    [u8; N + HEADER_BYTES]: Sized,
+{
+    bytes: [u8; N + HEADER_BYTES],
+    used: usize,
+}
+
+impl<const N: usize> FrameBuf<N>
+where
+    [u8; N + HEADER_BYTES]: Sized,
+{
+    pub fn new() -> Self {
+        FrameBuf {
+            bytes: [0; N + HEADER_BYTES],
+            used: 0,
+        }
+    }
+
+    pub fn capacity(&self) -> usize {
+        N
+    }
+
+    pub fn remaining(&self) -> usize {
+        N + HEADER_BYTES - self.used
+    }
+
+    pub fn push(&mut self, byte: u8) -> bool {
+        if self.used < self.bytes.len() {
+            self.bytes[self.used] = byte;
+            self.used += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.bytes[..self.used]
+    }
+}
+
+pub fn checksum(data: &[u8]) -> u16 {
+    let mut acc: u16 = 0;
+    for &b in data {
+        acc = acc.wrapping_mul(31).wrapping_add(u16::from(b));
+    }
+    acc
+}
+
+pub fn encode_header(header: &Header, out: &mut Vec<u8>) {
+    out.push(header.version);
+    out.push(header.flags);
+    out.extend_from_slice(&header.length.to_be_bytes());
+    let crc = checksum(&out[out.len() - 4..]);
+    out.extend_from_slice(&crc.to_be_bytes());
+}

--- a/evaluation/corpus/rustc-1941-gce-braced-const-arg-ice/result.json
+++ b/evaluation/corpus/rustc-1941-gce-braced-const-arg-ice/result.json
@@ -1,0 +1,10 @@
+{
+  "id": "rustc-1941-gce-braced-const-arg-ice",
+  "status": "ok",
+  "original_bytes": 2480,
+  "reduced_bytes": 141,
+  "original_nows_bytes": 1847,
+  "reduced_nows_bytes": 111,
+  "seconds": 76.9,
+  "ratio": 94.3
+}

--- a/evaluation/corpus/rustc-1941-gce-braced-const-arg-ice/result.json
+++ b/evaluation/corpus/rustc-1941-gce-braced-const-arg-ice/result.json
@@ -5,6 +5,6 @@
   "reduced_bytes": 141,
   "original_nows_bytes": 1847,
   "reduced_nows_bytes": 111,
-  "seconds": 76.9,
+  "seconds": 61.0,
   "ratio": 94.3
 }

--- a/evaluation/corpus/rustc-1941-gce-braced-const-arg-ice/setup.sh
+++ b/evaluation/corpus/rustc-1941-gce-braced-const-arg-ice/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -eu
+# The oracle invokes the pinned toolchain via `rustc +1.94.1`, which
+# requires rustup. Installing an already-present toolchain is a no-op.
+rustup toolchain install 1.94.1 --profile minimal

--- a/evaluation/corpus/rustc-1941-gce-braced-const-arg-ice/shrinkray_reduced.rs
+++ b/evaluation/corpus/rustc-1941-gce-braced-const-arg-ice/shrinkray_reduced.rs
@@ -1,5 +1,5 @@
 #![feature(generic_const_exprs)]struct c {}
-trait a<const a:c> {}
+trait a<const b:c> {}
 impl<const b>a c where c:a<b> {}
 impl<const b:c>a< {
   {

--- a/evaluation/corpus/rustc-1941-gce-braced-const-arg-ice/shrinkray_reduced.rs
+++ b/evaluation/corpus/rustc-1941-gce-braced-const-arg-ice/shrinkray_reduced.rs
@@ -1,0 +1,9 @@
+#![feature(generic_const_exprs)]struct c {}
+trait a<const a:c> {}
+impl<const b>a c where c:a<b> {}
+impl<const b:c>a< {
+  {
+    b
+  }
+}
+>c {}

--- a/evaluation/corpus/terser-5151-forof-empty-pattern-crash/meta.json
+++ b/evaluation/corpus/terser-5151-forof-empty-pattern-crash/meta.json
@@ -1,0 +1,26 @@
+{
+  "id": "terser-5151-forof-empty-pattern-crash",
+  "format": "javascript",
+  "tool": "terser 5.15.1",
+  "extension": ".js",
+  "bug_url": "https://github.com/terser/terser/issues/1293",
+  "symptom": "terser 5.15.1's compress pass crashes with 'TypeError: Cannot read properties of undefined (reading value)' in join_object_assignments when a for-of loop with an empty array destructuring pattern ('for (var [] of xs)') sits inside a statically-falsy conditional, whose dead-branch handling runs join_consecutive_vars over the loop head.",
+  "oracle": {
+    "type": "command",
+    "setup": "setup.sh",
+    "command": [
+      "{tools}/terser-5.15.1/node_modules/.bin/terser",
+      "{file}",
+      "-c",
+      "unsafe=false"
+    ]
+  },
+  "interesting": {
+    "output_contains": [
+      "Cannot read properties of undefined (reading 'value')",
+      "at join_object_assignments"
+    ],
+    "exit_code": 1
+  },
+  "timeout": 10
+}

--- a/evaluation/corpus/terser-5151-forof-empty-pattern-crash/original.js
+++ b/evaluation/corpus/terser-5151-forof-empty-pattern-crash/original.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const DEFAULT_BATCH_SIZE = 64;
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 250;
+// Flipped on locally when debugging queue drain stalls; keep 0 in production.
+const TRACE_DRAIN = 0;
+
+function clamp(value, lo, hi) {
+  if (value < lo) return lo;
+  if (value > hi) return hi;
+  return value;
+}
+
+function chunk(items, size) {
+  const out = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+class MetricsRegistry {
+  constructor() {
+    this.counters = new Map();
+    this.gauges = new Map();
+  }
+
+  increment(name, delta) {
+    const current = this.counters.get(name) || 0;
+    this.counters.set(name, current + (delta === undefined ? 1 : delta));
+  }
+
+  gauge(name, value) {
+    this.gauges.set(name, value);
+  }
+
+  snapshot() {
+    const result = {};
+    for (const [name, value] of this.counters) {
+      result[name] = value;
+    }
+    for (const [name, value] of this.gauges) {
+      result[name] = value;
+    }
+    return result;
+  }
+}
+
+const metrics = new MetricsRegistry();
+
+function parseRecord(line) {
+  const parts = line.split('\t');
+  if (parts.length < 3) {
+    metrics.increment('parse.malformed');
+    return null;
+  }
+  const [id, kind, payload] = parts;
+  return { id, kind, payload: payload.trim() };
+}
+
+function drainQueue(queue, batches) {
+  // Tracing walks every ready batch without keeping any fields; the
+  // empty pattern is deliberate, we only care that iteration advances
+  // the underlying cursor.
+  while (TRACE_DRAIN) for (var [] of batches) metrics.increment('drain.trace');
+  metrics.gauge('queue.depth', queue.depth());
+}
+
+function summarise(records) {
+  const byKind = new Map();
+  for (const record of records) {
+    if (!record) continue;
+    const bucket = byKind.get(record.kind) || [];
+    bucket.push(record.id);
+    byKind.set(record.kind, bucket);
+  }
+  const summary = [];
+  for (const [kind, ids] of byKind) {
+    summary.push({ kind, count: ids.length, sample: ids.slice(0, 5) });
+  }
+  summary.sort((a, b) => b.count - a.count);
+  return summary;
+}
+
+async function withRetries(fn, label) {
+  let lastError = null;
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      metrics.increment('retry.' + label);
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS * (attempt + 1)));
+    }
+  }
+  throw lastError;
+}
+
+function processInput(text, options) {
+  const size = clamp(options.batchSize || DEFAULT_BATCH_SIZE, 1, 1024);
+  const records = text.split('\n').filter(Boolean).map(parseRecord);
+  const batches = chunk(records, size);
+  drainQueue({ pending: 0, depth: () => 0 }, batches);
+  metrics.increment('batches.processed', batches.length);
+  return summarise(records);
+}
+
+module.exports = {
+  chunk,
+  clamp,
+  drainQueue,
+  MetricsRegistry,
+  parseRecord,
+  processInput,
+  summarise,
+  withRetries,
+};

--- a/evaluation/corpus/terser-5151-forof-empty-pattern-crash/result.json
+++ b/evaluation/corpus/terser-5151-forof-empty-pattern-crash/result.json
@@ -1,0 +1,10 @@
+{
+  "id": "terser-5151-forof-empty-pattern-crash",
+  "status": "ok",
+  "original_bytes": 2945,
+  "reduced_bytes": 24,
+  "original_nows_bytes": 2326,
+  "reduced_nows_bytes": 22,
+  "seconds": 44.3,
+  "ratio": 99.2
+}

--- a/evaluation/corpus/terser-5151-forof-empty-pattern-crash/setup.sh
+++ b/evaluation/corpus/terser-5151-forof-empty-pattern-crash/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eu
+DEST="$TOOLS_DIR/terser-5.15.1"
+[ -x "$DEST/node_modules/.bin/terser" ] && exit 0
+rm -rf "$DEST"
+mkdir -p "$DEST"
+cd "$DEST"
+# Pin exactly 5.15.1: the crash is fixed in later releases.
+npm install --no-save --no-audit --no-fund terser@5.15.1

--- a/evaluation/corpus/terser-5151-forof-empty-pattern-crash/shrinkray_reduced.js
+++ b/evaluation/corpus/terser-5151-forof-empty-pattern-crash/shrinkray_reduced.js
@@ -1,0 +1,1 @@
+while(0)for(var[]of 0);

--- a/notes/reduction-passes.md
+++ b/notes/reduction-passes.md
@@ -32,6 +32,24 @@ Passes for DIMACS CNF files (SAT solver input format). Includes clause deletion,
 
 C/C++ passes built on a sloppy lexer plus bracket matching (a pure Python replacement for creduce's `clang_delta`, which shrink ray previously shelled out to). Rather than parsing properly, these find things that look like functions, namespaces, class heads, templates, call expressions and typedefs, then overgenerate candidate edits and let the interestingness test reject the wrong ones. Includes `replace_function_bodies` (function def -> declaration), `delete_function_definitions`, `remove_namespaces` (including `extern "C"`), `remove_base_classes`, `remove_constructor_initializers`, `remove_template_parts`, `replace_type_with_int`, and `simplify_call_expressions`, plus two **pumps** (which may temporarily increase code size): `inline_typedefs` and `inline_function_calls`.
 
+### treesitter.py
+
+Grammar-aware passes for any language with a grammar in
+tree-sitter-language-pack, selected by file extension (Go, Rust,
+JavaScript, Java, and many more; JSON and DIMACS CNF keep their dedicated
+passes only). tree-sitter is a parser rather than a generator, but nodes
+carry byte offsets, so every transformation is expressed through the
+ordinary `Cuts`/`Replacements` patch machinery: `delete_children` (runs of
+named children, eating adjacent separators), `lift_nodes` (replace a node
+with a same-type descendant from any depth, or any named descendant within
+two levels), `delete_orphaned_declarations` (delete a node together with
+top-level declarations/imports left textually unreferenced — the pass that
+makes dead code deletable in languages like Go that reject unused
+imports), and `substitute_nodes` (replace a node's text with the smallest
+same-type text in the file). tree-sitter parses broken input tolerantly,
+so these passes keep working on syntactically-invalid intermediate states.
+See `evaluation/RESULTS.md` for the evaluation that motivated them.
+
 ## Pass Ordering in ShrinkRay
 
 The `ShrinkRay` reducer organises passes into stages:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
     "exceptiongroup>=1.2.0",
     "binaryornot>=0.4.4",
     "black>=24.1.0",
+    "tree-sitter>=0.26.0",
+    "tree-sitter-language-pack>=1.12.2",
 ]
 
 [project.urls]

--- a/src/shrinkray/passes/treesitter.py
+++ b/src/shrinkray/passes/treesitter.py
@@ -26,6 +26,7 @@ so these passes keep working on the syntactically-broken intermediate
 states other passes produce.
 """
 
+import bisect
 import os
 import re
 from collections.abc import Iterator
@@ -136,29 +137,32 @@ def child_deletion_cuts(tree: tree_sitter.Tree, source: bytes) -> list[CutPatch]
     cuts: list[CutPatch] = []
     for node in iter_nodes(tree):
         children = node.children
-        named = [c for c in children if c.is_named]
-        for i, child in enumerate(named):
+        # Positions of the named children within the full child list, so
+        # adjacent anonymous tokens can be found without rescanning.
+        named_indices = [j for j, c in enumerate(children) if c.is_named]
+        for i, idx_first in enumerate(named_indices):
+            child = children[idx_first]
             for run in range(1, MAX_CHILD_RUN + 1):
-                if i + run > len(named):
+                if i + run > len(named_indices):
                     break
-                last = named[i + run - 1]
+                idx_last = named_indices[i + run - 1]
+                last = children[idx_last]
                 start, end = child.start_byte, last.end_byte
                 if end == start:
                     continue
                 cuts.append([(start, end)])
                 # A variant extending to the next named sibling's start,
                 # eating the whitespace/newlines between them.
-                if i + run < len(named):
-                    cuts.append([(start, named[i + run].start_byte)])
+                if i + run < len(named_indices):
+                    after_run = children[named_indices[i + run]]
+                    cuts.append([(start, after_run.start_byte)])
                 # Variants that also eat a separator token next to the
                 # run, so deleting `bbb` from `f(aaa, bbb)` can remove
                 # the now-dangling comma too.
-                idx_last = children.index(last)
                 if idx_last + 1 < len(children):
                     after = children[idx_last + 1]
                     if source[after.start_byte : after.end_byte] in SEPARATOR_TOKENS:
                         cuts.append([(start, after.end_byte)])
-                idx_first = children.index(child)
                 if idx_first > 0:
                     before = children[idx_first - 1]
                     if source[before.start_byte : before.end_byte] in SEPARATOR_TOKENS:
@@ -167,19 +171,22 @@ def child_deletion_cuts(tree: tree_sitter.Tree, source: bytes) -> list[CutPatch]
 
 
 # How deep below a node to look for arbitrary named descendants to
-# promote into its place. Same-type descendants are hoisted from any
-# depth; for arbitrary descendants an unbounded search would generate
-# quadratically many mostly-nonsensical candidates.
+# promote into its place. Same-type descendants are hoisted from
+# arbitrarily far down (but only the nearest one along each path — the
+# pass reapplies, so deeper ones are reached stepwise); for arbitrary
+# descendants an unbounded search would generate quadratically many
+# mostly-nonsensical candidates.
 MAX_PROMOTION_DEPTH = 2
 
 
 def lift_cuts(tree: tree_sitter.Tree, source: bytes) -> list[CutPatch]:
     """Cuts replacing a node with one of its named descendants.
 
-    A descendant of the same node type is lifted from any depth (e.g.
-    replacing an `if` with an `if` nested inside it); any named
-    descendant is promoted from within MAX_PROMOTION_DEPTH levels (e.g.
-    replacing a parenthesized expression with its contents).
+    The nearest descendant of the same node type along each path is
+    lifted regardless of depth (e.g. replacing an `if` with an `if`
+    nested inside it); any named descendant is promoted from within
+    MAX_PROMOTION_DEPTH levels (e.g. replacing a parenthesized
+    expression with its contents).
     """
     cuts: list[CutPatch] = []
     for node in iter_nodes(tree):
@@ -190,12 +197,20 @@ def lift_cuts(tree: tree_sitter.Tree, source: bytes) -> list[CutPatch]:
         while stack:
             descendant, depth = stack.pop()
             d_span = (descendant.start_byte, descendant.end_byte)
-            if d_span != span and descendant.is_named:
-                same_type = descendant.type == node.type
+            same_type = (
+                descendant.is_named
+                and d_span != span
+                and descendant.type == node.type
+            )
+            if descendant.is_named and d_span != span:
                 if same_type or depth <= MAX_PROMOTION_DEPTH:
                     cut = [(span[0], d_span[0]), (d_span[1], span[1])]
                     cuts.append([t for t in cut if t[0] < t[1]])
-            stack.extend((child, depth + 1) for child in descendant.children)
+            # Stop below a same-type descendant: hoisting past it is
+            # reachable by applying the pass repeatedly, and descending
+            # regardless would make same-type chains quadratic.
+            if not same_type:
+                stack.extend((child, depth + 1) for child in descendant.children)
     return [c for c in cuts if c]
 
 
@@ -215,7 +230,13 @@ def _names_mentioned(node: tree_sitter.Node, source: bytes) -> frozenset[bytes]:
         if "string" in n.type:
             text = source[n.start_byte : n.end_byte].strip(b"\"'`")
             if text:
-                names.add(text.rsplit(b"/", 1)[-1])
+                basename = text.rsplit(b"/", 1)[-1]
+                names.add(basename)
+                # A dotted basename like "yaml.v2" is referenced by its
+                # leading word (Go imports gopkg.in/yaml.v2 as yaml).
+                word = _WORD.match(basename)
+                if word is not None:
+                    names.add(word.group())
         elif n.child_count == 0 and "identifier" in n.type:
             names.add(source[n.start_byte : n.end_byte])
         else:
@@ -223,14 +244,28 @@ def _names_mentioned(node: tree_sitter.Node, source: bytes) -> frozenset[bytes]:
     return frozenset(names)
 
 
-def _occurs_outside(
-    name: bytes, source: bytes, spans: list[tuple[int, int]]
-) -> bool:
-    pattern = rb"(?<![A-Za-z0-9_])" + re.escape(name) + rb"(?![A-Za-z0-9_])"
-    for match in re.finditer(pattern, source):
-        if not any(u <= match.start() < v for u, v in spans):
-            return True
-    return False
+_WORD = re.compile(rb"[A-Za-z0-9_]+")
+
+
+def _name_occurrences(source: bytes, names: set[bytes]) -> dict[bytes, list[int]]:
+    """Start offsets of each name's whole-word occurrences in source.
+
+    Names that are single word tokens (nearly all of them) are looked
+    up in one tokenizing scan of the source; anything else (e.g. an
+    import path basename like "yaml.v2") falls back to its own search.
+    """
+    tokens: dict[bytes, list[int]] = {}
+    for match in _WORD.finditer(source):
+        tokens.setdefault(match.group(), []).append(match.start())
+
+    occurrences: dict[bytes, list[int]] = {}
+    for name in names:
+        if _WORD.fullmatch(name):
+            occurrences[name] = tokens.get(name, [])
+        else:
+            pattern = rb"(?<![A-Za-z0-9_])" + re.escape(name) + rb"(?![A-Za-z0-9_])"
+            occurrences[name] = [m.start() for m in re.finditer(pattern, source)]
+    return occurrences
 
 
 def _gc_candidates(tree: tree_sitter.Tree) -> list[tree_sitter.Node]:
@@ -258,43 +293,156 @@ def _gc_candidates(tree: tree_sitter.Tree) -> list[tree_sitter.Node]:
     return result
 
 
+def _names_defined(node: tree_sitter.Node, source: bytes) -> frozenset[bytes]:
+    """The names a declaration binds, as far as we can tell.
+
+    Grammars conventionally expose a `name` field on declarations;
+    references to that name are what should keep the declaration
+    alive. Nodes without one (import entries in particular) fall back
+    to every name they mention, which is conservative in the right
+    direction: an import's mentioned names are exactly the names it
+    binds, while for odd declaration shapes it just means fewer orphan
+    candidates.
+    """
+    name_child = node.child_by_field_name("name")
+    if name_child is not None:
+        return frozenset({source[name_child.start_byte : name_child.end_byte]})
+    return _names_mentioned(node, source)
+
+
+def _covering_chain(
+    tree: tree_sitter.Tree, lo: int, hi: int
+) -> list[tuple[int, int]]:
+    """Spans of the named nodes whose span covers [lo, hi).
+
+    Nodes covering an interval always form a chain from the root down,
+    so this descends rather than scanning the whole tree.
+    """
+    spans = []
+    node = tree.root_node
+    while True:
+        # Package/module headers are excluded for the same reason they
+        # are not GC candidates: deleting one invalidates the file, so
+        # cuts triggered by it (e.g. deleting `package main` orphans
+        # `func main`) are wasted attempts.
+        if (
+            node.is_named
+            and "package" not in node.type
+            and node.start_byte <= lo
+            and hi <= node.end_byte
+        ):
+            span = (node.start_byte, node.end_byte)
+            if not spans or spans[-1] != span:
+                spans.append(span)
+        for child in node.children:
+            if child.start_byte <= lo and hi <= child.end_byte:
+                node = child
+                break
+        else:
+            return spans
+
+
 def orphaned_declaration_cuts(
     tree: tree_sitter.Tree, source: bytes
 ) -> list[CutPatch]:
     """Cuts deleting a node plus declarations it leaves unreferenced.
 
-    For every named node, tentatively delete it, then repeatedly delete
-    any eligible declaration none of whose names still occur outside
-    the deleted regions. Only combinations that collect at least one
-    extra declaration are returned: the plain single deletion is
-    already generated by other passes. This is what makes dead code
-    deletable in languages like Go that hard-error on unused imports.
+    Deleting a node X orphans an eligible declaration when all the
+    positions where the declaration's names occur (outside the
+    declaration itself) fall inside X; the orphan can then be deleted
+    along with X, cascading if that in turn orphans more declarations.
+    Declarations that are unreferenced to begin with are not collected:
+    a plain single cut, which other passes already generate, deletes
+    those. This joint deletion is what makes dead code deletable in
+    languages like Go that hard-error on unused imports.
     """
-    gc_nodes = [(n, _names_mentioned(n, source)) for n in _gc_candidates(tree)]
+    gc_nodes = [(n, _names_defined(n, source)) for n in _gc_candidates(tree)]
+    occurrences = _name_occurrences(
+        source, {name for _, names in gc_nodes for name in names}
+    )
+
+    def external_extent(index: int) -> tuple[int, int] | None:
+        """Smallest interval containing every position where the
+        candidate's names occur outside its own span, or None if it is
+        not referenced anywhere else at all."""
+        candidate, names = gc_nodes[index]
+        span = (candidate.start_byte, candidate.end_byte)
+        lo: int | None = None
+        hi: int | None = None
+        for name in names:
+            positions = occurrences[name]
+            # Positions inside the candidate's own span are contiguous
+            # in the sorted list; the external extremes sit just
+            # outside that region.
+            if positions and positions[0] < span[0]:
+                lo = positions[0] if lo is None else min(lo, positions[0])
+            if positions and positions[-1] >= span[1]:
+                hi = positions[-1] if hi is None else max(hi, positions[-1])
+            first_after = bisect.bisect_left(positions, span[1])
+            if first_after < len(positions):
+                lo = positions[first_after] if lo is None else min(lo, positions[first_after])
+            last_before = bisect.bisect_left(positions, span[0]) - 1
+            if last_before >= 0:
+                hi = positions[last_before] if hi is None else max(hi, positions[last_before])
+        if lo is None or hi is None:
+            return None
+        return lo, hi + 1
+
+    def is_orphaned(index: int, spans: list[tuple[int, int]]) -> bool:
+        """Whether every external reference to the candidate's names
+        lies within the deleted spans."""
+        candidate, names = gc_nodes[index]
+        own = (candidate.start_byte, candidate.end_byte)
+        for name in names:
+            for position in occurrences[name]:
+                if own[0] <= position < own[1]:
+                    continue
+                if not any(u <= position < v for u, v in spans):
+                    return False
+        return True
+
+    # The nodes whose deletion orphans a candidate in one step are
+    # exactly those whose span covers all its external references —
+    # a chain from the root down.
+    triggers: dict[tuple[int, int], list[int]] = {}
+    extents: list[tuple[int, int] | None] = []
+    for index in range(len(gc_nodes)):
+        extent = external_extent(index)
+        extents.append(extent)
+        if extent is None:
+            # Unreferenced to begin with: a plain single cut, which
+            # other passes already generate, deletes it.
+            continue
+        for span in _covering_chain(tree, *extent):
+            triggers.setdefault(span, []).append(index)
 
     cuts: list[CutPatch] = []
-    seen: set[tuple[tuple[int, int], ...]] = set()
-    for node in iter_nodes(tree):
-        if not node.is_named or node.start_byte == node.end_byte:
+    for x_span, indices in sorted(triggers.items()):
+        spans = [x_span]
+        spans.extend(
+            (g.start_byte, g.end_byte)
+            for i in indices
+            for g in [gc_nodes[i][0]]
+            # A candidate overlapping the deleted node is already gone.
+            if not (g.start_byte < x_span[1] and x_span[0] < g.end_byte)
+        )
+        if len(spans) < 2:
             continue
-        spans = [(node.start_byte, node.end_byte)]
+        # Cascade: deleting these regions may orphan further
+        # declarations whose references lived inside them.
         changed = True
         while changed:
             changed = False
-            for candidate, names in gc_nodes:
+            for index, (candidate, _) in enumerate(gc_nodes):
                 span = (candidate.start_byte, candidate.end_byte)
+                if extents[index] is None:
+                    continue
                 if any(u < span[1] and span[0] < v for u, v in spans):
                     continue
-                if not any(
-                    _occurs_outside(name, source, [*spans, span]) for name in names
-                ):
+                if is_orphaned(index, spans):
                     spans.append(span)
                     changed = True
-        if len(spans) > 1:
-            key = tuple(sorted(spans))
-            if key not in seen:
-                seen.add(key)
-                cuts.append(sorted(spans))
+        cuts.append(sorted(set(spans)))
     return cuts
 
 

--- a/src/shrinkray/passes/treesitter.py
+++ b/src/shrinkray/passes/treesitter.py
@@ -1,0 +1,361 @@
+"""Grammar-aware reduction passes built on tree-sitter.
+
+tree-sitter is a parser, not a code generator, but that is enough for
+reduction: every node carries the byte range of its source text, so
+transformations can be expressed as byte-range patches (Cuts and
+Replacements) against the current test case. These passes provide
+structure-aware reductions for any language with a grammar in
+tree-sitter-language-pack, without needing per-language code:
+
+- delete_children: delete runs of named child nodes (statements,
+  arguments, ...), eating adjacent separator tokens like `,`/`;`.
+- lift_nodes: replace a node with one of its named descendants — a
+  same-type descendant at any depth (grammar-aware lift_braces), or any
+  named descendant within a couple of levels (grammar-aware debracket).
+- delete_orphaned_declarations: delete a node together with any
+  top-level declarations or import entries whose names no longer occur
+  anywhere else. This finds coupled deletions that single cuts cannot:
+  e.g. Go rejects programs with unused imports, so a dead function and
+  the imports only it uses can only be deleted together.
+- substitute_nodes: replace a node's text with the smallest text seen
+  elsewhere in the file for a node of the same type (e.g. replacing a
+  long call expression with a short one appearing later).
+
+tree-sitter parses erroneous input tolerantly (inserting ERROR nodes),
+so these passes keep working on the syntactically-broken intermediate
+states other passes produce.
+"""
+
+import os
+import re
+from collections.abc import Iterator
+
+import tree_sitter
+import tree_sitter_language_pack
+
+from shrinkray.passes.definitions import ReductionPass
+from shrinkray.passes.patching import (
+    CutPatch,
+    Cuts,
+    ReplacementPatch,
+    Replacements,
+    apply_patches,
+)
+from shrinkray.problem import ReductionProblem
+
+
+# Extensions shrink ray maps to tree-sitter grammars. Formats with
+# dedicated, complete pass support (JSON, DIMACS CNF) are deliberately
+# absent; languages that have some dedicated passes but incomplete ones
+# (Python, C/C++) are included because these passes still add
+# capabilities (e.g. coupled import deletion) on top of them.
+EXTENSION_LANGUAGES: dict[str, str] = {
+    ".c": "c",
+    ".cc": "cpp",
+    ".cpp": "cpp",
+    ".cs": "csharp",
+    ".css": "css",
+    ".cxx": "cpp",
+    ".d": "d",
+    ".dart": "dart",
+    ".el": "elisp",
+    ".erl": "erlang",
+    ".ex": "elixir",
+    ".exs": "elixir",
+    ".go": "go",
+    ".h": "cpp",
+    ".hh": "cpp",
+    ".hpp": "cpp",
+    ".hs": "haskell",
+    ".html": "html",
+    ".java": "java",
+    ".jl": "julia",
+    ".js": "javascript",
+    # The javascript grammar includes JSX syntax.
+    ".jsx": "javascript",
+    ".kt": "kotlin",
+    ".lua": "lua",
+    ".m": "objc",
+    ".ml": "ocaml",
+    ".mjs": "javascript",
+    ".nim": "nim",
+    ".php": "php",
+    ".pl": "perl",
+    ".py": "python",
+    ".r": "r",
+    ".rb": "ruby",
+    ".rs": "rust",
+    ".scala": "scala",
+    ".sh": "bash",
+    ".sql": "sql",
+    ".swift": "swift",
+    ".toml": "toml",
+    ".ts": "typescript",
+    ".tsx": "tsx",
+    ".vim": "vim",
+    ".yaml": "yaml",
+    ".yml": "yaml",
+    ".zig": "zig",
+}
+
+
+def language_for_filename(filename: str) -> str | None:
+    """The tree-sitter language for a file, judged by its extension."""
+    ext = os.path.splitext(filename)[1].lower()
+    return EXTENSION_LANGUAGES.get(ext)
+
+
+def parse_tree(language: str, source: bytes) -> tree_sitter.Tree:
+    """Parse source with the named grammar.
+
+    tree-sitter is error-tolerant: any input parses, with unparseable
+    regions wrapped in ERROR nodes.
+    """
+    parser = tree_sitter.Parser(tree_sitter_language_pack.get_language(language))
+    return parser.parse(source)
+
+
+def iter_nodes(tree: tree_sitter.Tree) -> Iterator[tree_sitter.Node]:
+    stack = [tree.root_node]
+    while stack:
+        node = stack.pop()
+        yield node
+        stack.extend(reversed(node.children))
+
+
+SEPARATOR_TOKENS = (b",", b";")
+
+# Length of the longest run of adjacent children deleted as one patch.
+# Runs beyond this are reachable by combining patches (the patch
+# applier merges compatible cuts), so longer runs add little.
+MAX_CHILD_RUN = 3
+
+
+def child_deletion_cuts(tree: tree_sitter.Tree, source: bytes) -> list[CutPatch]:
+    """Cuts deleting runs of named children, eating adjacent separators."""
+    cuts: list[CutPatch] = []
+    for node in iter_nodes(tree):
+        children = node.children
+        named = [c for c in children if c.is_named]
+        for i, child in enumerate(named):
+            for run in range(1, MAX_CHILD_RUN + 1):
+                if i + run > len(named):
+                    break
+                last = named[i + run - 1]
+                start, end = child.start_byte, last.end_byte
+                if end == start:
+                    continue
+                cuts.append([(start, end)])
+                # A variant extending to the next named sibling's start,
+                # eating the whitespace/newlines between them.
+                if i + run < len(named):
+                    cuts.append([(start, named[i + run].start_byte)])
+                # Variants that also eat a separator token next to the
+                # run, so deleting `bbb` from `f(aaa, bbb)` can remove
+                # the now-dangling comma too.
+                idx_last = children.index(last)
+                if idx_last + 1 < len(children):
+                    after = children[idx_last + 1]
+                    if source[after.start_byte : after.end_byte] in SEPARATOR_TOKENS:
+                        cuts.append([(start, after.end_byte)])
+                idx_first = children.index(child)
+                if idx_first > 0:
+                    before = children[idx_first - 1]
+                    if source[before.start_byte : before.end_byte] in SEPARATOR_TOKENS:
+                        cuts.append([(before.start_byte, end)])
+    return cuts
+
+
+# How deep below a node to look for arbitrary named descendants to
+# promote into its place. Same-type descendants are hoisted from any
+# depth; for arbitrary descendants an unbounded search would generate
+# quadratically many mostly-nonsensical candidates.
+MAX_PROMOTION_DEPTH = 2
+
+
+def lift_cuts(tree: tree_sitter.Tree, source: bytes) -> list[CutPatch]:
+    """Cuts replacing a node with one of its named descendants.
+
+    A descendant of the same node type is lifted from any depth (e.g.
+    replacing an `if` with an `if` nested inside it); any named
+    descendant is promoted from within MAX_PROMOTION_DEPTH levels (e.g.
+    replacing a parenthesized expression with its contents).
+    """
+    cuts: list[CutPatch] = []
+    for node in iter_nodes(tree):
+        if not node.is_named:
+            continue
+        span = (node.start_byte, node.end_byte)
+        stack = [(child, 1) for child in node.children]
+        while stack:
+            descendant, depth = stack.pop()
+            d_span = (descendant.start_byte, descendant.end_byte)
+            if d_span != span and descendant.is_named:
+                same_type = descendant.type == node.type
+                if same_type or depth <= MAX_PROMOTION_DEPTH:
+                    cut = [(span[0], d_span[0]), (d_span[1], span[1])]
+                    cuts.append([t for t in cut if t[0] < t[1]])
+            stack.extend((child, depth + 1) for child in descendant.children)
+    return [c for c in cuts if c]
+
+
+def _is_import_like(node_type: str) -> bool:
+    words = node_type.split("_")
+    return any(w in ("import", "imports", "use") for w in words)
+
+
+def _names_mentioned(node: tree_sitter.Node, source: bytes) -> frozenset[bytes]:
+    """Names a node mentions: identifier tokens, plus final path
+    segments of string literals (covering import paths like
+    "path/filepath", whose usable name is `filepath`)."""
+    names = set()
+    stack = [node]
+    while stack:
+        n = stack.pop()
+        if "string" in n.type:
+            text = source[n.start_byte : n.end_byte].strip(b"\"'`")
+            if text:
+                names.add(text.rsplit(b"/", 1)[-1])
+        elif n.child_count == 0 and "identifier" in n.type:
+            names.add(source[n.start_byte : n.end_byte])
+        else:
+            stack.extend(n.children)
+    return frozenset(names)
+
+
+def _occurs_outside(
+    name: bytes, source: bytes, spans: list[tuple[int, int]]
+) -> bool:
+    pattern = rb"(?<![A-Za-z0-9_])" + re.escape(name) + rb"(?![A-Za-z0-9_])"
+    for match in re.finditer(pattern, source):
+        if not any(u <= match.start() < v for u, v in spans):
+            return True
+    return False
+
+
+def _gc_candidates(tree: tree_sitter.Tree) -> list[tree_sitter.Node]:
+    """Nodes eligible for orphan collection: top-level declarations
+    (except package/module headers, which nothing references by name
+    but whose deletion invalidates the file) and entries of import-like
+    constructs (which are syntactically self-contained)."""
+    result = []
+    for child in tree.root_node.children:
+        if (
+            child.is_named
+            and "package" not in child.type
+            and "module" not in child.type
+        ):
+            result.append(child)
+        stack = [(child, _is_import_like(child.type))]
+        while stack:
+            node, in_import = stack.pop()
+            for grandchild in node.children:
+                if grandchild.is_named and in_import:
+                    result.append(grandchild)
+                stack.append(
+                    (grandchild, in_import or _is_import_like(grandchild.type))
+                )
+    return result
+
+
+def orphaned_declaration_cuts(
+    tree: tree_sitter.Tree, source: bytes
+) -> list[CutPatch]:
+    """Cuts deleting a node plus declarations it leaves unreferenced.
+
+    For every named node, tentatively delete it, then repeatedly delete
+    any eligible declaration none of whose names still occur outside
+    the deleted regions. Only combinations that collect at least one
+    extra declaration are returned: the plain single deletion is
+    already generated by other passes. This is what makes dead code
+    deletable in languages like Go that hard-error on unused imports.
+    """
+    gc_nodes = [(n, _names_mentioned(n, source)) for n in _gc_candidates(tree)]
+
+    cuts: list[CutPatch] = []
+    seen: set[tuple[tuple[int, int], ...]] = set()
+    for node in iter_nodes(tree):
+        if not node.is_named or node.start_byte == node.end_byte:
+            continue
+        spans = [(node.start_byte, node.end_byte)]
+        changed = True
+        while changed:
+            changed = False
+            for candidate, names in gc_nodes:
+                span = (candidate.start_byte, candidate.end_byte)
+                if any(u < span[1] and span[0] < v for u, v in spans):
+                    continue
+                if not any(
+                    _occurs_outside(name, source, [*spans, span]) for name in names
+                ):
+                    spans.append(span)
+                    changed = True
+        if len(spans) > 1:
+            key = tuple(sorted(spans))
+            if key not in seen:
+                seen.add(key)
+                cuts.append(sorted(spans))
+    return cuts
+
+
+def minimal_substitutions(
+    tree: tree_sitter.Tree, source: bytes
+) -> list[ReplacementPatch]:
+    """Replace nodes with the smallest same-type text in the file.
+
+    This is the "remember strings you've seen for each node type" idea:
+    it cannot invent replacements, but a file being reduced usually
+    already contains a small instance of most node types (a short call,
+    a trivial block), and swapping one in unlocks further deletion.
+    """
+    minimal: dict[str, bytes] = {}
+    named = [n for n in iter_nodes(tree) if n.is_named]
+    for node in named:
+        text = source[node.start_byte : node.end_byte]
+        best = minimal.get(node.type)
+        if best is None or (len(text), text) < (len(best), best):
+            minimal[node.type] = text
+
+    patches: list[ReplacementPatch] = []
+    for node in named:
+        text = source[node.start_byte : node.end_byte]
+        replacement = minimal[node.type]
+        if len(replacement) < len(text):
+            patches.append(((node.start_byte, node.end_byte, replacement),))
+    return patches
+
+
+def _cut_pass(
+    language: str,
+    name: str,
+    generator,
+) -> ReductionPass[bytes]:
+    async def run(problem: ReductionProblem[bytes]) -> None:
+        source = problem.current_test_case
+        cuts = generator(parse_tree(language, source), source)
+        await apply_patches(problem, Cuts(), cuts)
+
+    run.__name__ = f"treesitter({language})/{name}"
+    return run
+
+
+def _substitution_pass(language: str) -> ReductionPass[bytes]:
+    async def run(problem: ReductionProblem[bytes]) -> None:
+        source = problem.current_test_case
+        patches = minimal_substitutions(parse_tree(language, source), source)
+        await apply_patches(problem, Replacements(), patches)
+
+    run.__name__ = f"treesitter({language})/substitute_nodes"
+    return run
+
+
+def treesitter_passes(language: str) -> list[ReductionPass[bytes]]:
+    """Grammar-aware passes for a language, in rough order of value."""
+    return [
+        _cut_pass(language, "delete_children", child_deletion_cuts),
+        _cut_pass(
+            language, "delete_orphaned_declarations", orphaned_declaration_cuts
+        ),
+        _cut_pass(language, "lift_nodes", lift_cuts),
+        _substitution_pass(language),
+    ]

--- a/src/shrinkray/passes/treesitter.py
+++ b/src/shrinkray/passes/treesitter.py
@@ -198,9 +198,7 @@ def lift_cuts(tree: tree_sitter.Tree, source: bytes) -> list[CutPatch]:
             descendant, depth = stack.pop()
             d_span = (descendant.start_byte, descendant.end_byte)
             same_type = (
-                descendant.is_named
-                and d_span != span
-                and descendant.type == node.type
+                descendant.is_named and d_span != span and descendant.type == node.type
             )
             if descendant.is_named and d_span != span:
                 if same_type or depth <= MAX_PROMOTION_DEPTH:
@@ -310,9 +308,7 @@ def _names_defined(node: tree_sitter.Node, source: bytes) -> frozenset[bytes]:
     return _names_mentioned(node, source)
 
 
-def _covering_chain(
-    tree: tree_sitter.Tree, lo: int, hi: int
-) -> list[tuple[int, int]]:
+def _covering_chain(tree: tree_sitter.Tree, lo: int, hi: int) -> list[tuple[int, int]]:
     """Spans of the named nodes whose span covers [lo, hi).
 
     Nodes covering an interval always form a chain from the root down,
@@ -342,9 +338,7 @@ def _covering_chain(
             return spans
 
 
-def orphaned_declaration_cuts(
-    tree: tree_sitter.Tree, source: bytes
-) -> list[CutPatch]:
+def orphaned_declaration_cuts(tree: tree_sitter.Tree, source: bytes) -> list[CutPatch]:
     """Cuts deleting a node plus declarations it leaves unreferenced.
 
     Deleting a node X orphans an eligible declaration when all the
@@ -380,10 +374,18 @@ def orphaned_declaration_cuts(
                 hi = positions[-1] if hi is None else max(hi, positions[-1])
             first_after = bisect.bisect_left(positions, span[1])
             if first_after < len(positions):
-                lo = positions[first_after] if lo is None else min(lo, positions[first_after])
+                lo = (
+                    positions[first_after]
+                    if lo is None
+                    else min(lo, positions[first_after])
+                )
             last_before = bisect.bisect_left(positions, span[0]) - 1
             if last_before >= 0:
-                hi = positions[last_before] if hi is None else max(hi, positions[last_before])
+                hi = (
+                    positions[last_before]
+                    if hi is None
+                    else max(hi, positions[last_before])
+                )
         if lo is None or hi is None:
             return None
         return lo, hi + 1
@@ -501,9 +503,7 @@ def treesitter_passes(language: str) -> list[ReductionPass[bytes]]:
     """Grammar-aware passes for a language, in rough order of value."""
     return [
         _cut_pass(language, "delete_children", child_deletion_cuts),
-        _cut_pass(
-            language, "delete_orphaned_declarations", orphaned_declaration_cuts
-        ),
+        _cut_pass(language, "delete_orphaned_declarations", orphaned_declaration_cuts),
         _cut_pass(language, "lift_nodes", lift_cuts),
         _substitution_pass(language),
     ]

--- a/src/shrinkray/reducer.py
+++ b/src/shrinkray/reducer.py
@@ -49,6 +49,7 @@ from shrinkray.passes.patching import PatchApplier, Patches
 from shrinkray.passes.python import PYTHON_PASSES, is_python
 from shrinkray.passes.sat import SAT_PASSES, DimacsCNF
 from shrinkray.passes.sequences import block_deletion, delete_duplicates
+from shrinkray.passes.treesitter import language_for_filename, treesitter_passes
 from shrinkray.problem import (
     ReductionProblem,
     ReductionStats,
@@ -142,6 +143,10 @@ class ShrinkRay(Reducer[bytes]):
     # Enables the C/C++ specific passes and pumps. Set when the test
     # case's file name suggests it's C or C++.
     enable_cpp_passes: bool = False
+
+    # Enables grammar-aware passes for the named tree-sitter language.
+    # Set from the test case's file extension.
+    treesitter_language: str | None = None
 
     current_pump: ReductionPump[bytes] | None = None
 
@@ -279,6 +284,10 @@ class ShrinkRay(Reducer[bytes]):
         if self.enable_cpp_passes:
             self.great_passes.extend(CPP_PASSES)
             self.initial_cuts.extend(CPP_PASSES)
+        if self.treesitter_language is not None:
+            passes = treesitter_passes(self.treesitter_language)
+            self.great_passes.extend(passes)
+            self.initial_cuts.extend(passes)
         self.register_format_specific_pass(JSON, JSON_PASSES)
         self.register_format_specific_pass(
             DimacsCNF,
@@ -661,6 +670,7 @@ class DirectoryShrinkRay(Reducer[dict[str, bytes]]):
                 )
                 key_shrinkray = ShrinkRay(
                     enable_cpp_passes=any(k.endswith(s) for s in C_FILE_EXTENSIONS),
+                    treesitter_language=language_for_filename(k),
                     target=key_problem,
                 )
                 nursery.start_soon(key_shrinkray.run)

--- a/src/shrinkray/state.py
+++ b/src/shrinkray/state.py
@@ -29,6 +29,7 @@ from shrinkray.history import (
     serialize_directory,
 )
 from shrinkray.passes.cpp import C_FILE_EXTENSIONS
+from shrinkray.passes.treesitter import language_for_filename
 from shrinkray.problem import (
     BasicReductionProblem,
     InterestingnessResult,
@@ -976,6 +977,7 @@ class ShrinkRayStateSingleFile(ShrinkRayState[bytes]):
         return ShrinkRay(
             problem,
             enable_cpp_passes=os.path.splitext(self.filename)[1] in C_FILE_EXTENSIONS,
+            treesitter_language=language_for_filename(self.filename),
         )
 
     def _get_initial_bytes(self) -> bytes:

--- a/tests/test_treesitter_passes.py
+++ b/tests/test_treesitter_passes.py
@@ -1,0 +1,288 @@
+from shrinkray.passes.treesitter import (
+    EXTENSION_LANGUAGES,
+    child_deletion_cuts,
+    language_for_filename,
+    lift_cuts,
+    minimal_substitutions,
+    orphaned_declaration_cuts,
+    parse_tree,
+    treesitter_passes,
+)
+from shrinkray.problem import BasicReductionProblem
+from shrinkray.reducer import ShrinkRay
+from shrinkray.work import WorkContext
+from tests.helpers import reduce_with
+
+
+def apply_cuts(source: bytes, cuts: list[tuple[int, int]]) -> bytes:
+    parts = []
+    prev = 0
+    for u, v in sorted(cuts):
+        parts.append(source[prev:u])
+        prev = v
+    parts.append(source[prev:])
+    return b"".join(parts)
+
+
+# === language detection ===
+
+
+def test_language_for_known_extensions():
+    assert language_for_filename("foo.go") == "go"
+    assert language_for_filename("foo.rs") == "rust"
+    assert language_for_filename("/some/path/foo.js") == "javascript"
+    assert language_for_filename("FOO.GO") == "go"
+
+
+def test_language_for_unknown_extension():
+    assert language_for_filename("foo.unknownext") is None
+    assert language_for_filename("foo") is None
+
+
+def test_all_mapped_languages_are_loadable_and_parse():
+    for language in sorted(set(EXTENSION_LANGUAGES.values())):
+        tree = parse_tree(language, b"")
+        assert tree is not None, language
+
+
+def test_parse_tree_handles_non_utf8_bytes():
+    tree = parse_tree("go", b"package main\n\xff\xfe\nfunc f() {}\n")
+    assert tree is not None
+
+
+# === child deletion ===
+
+
+def test_child_deletion_can_remove_call_argument_with_separator():
+    source = b"f(aaa, bbb, ccc)"
+    tree = parse_tree("javascript", source)
+    cuts = child_deletion_cuts(tree, source)
+    results = {apply_cuts(source, cut) for cut in cuts}
+    # Deleting an inner argument must also eat a separating comma.
+    assert b"f(aaa, ccc)" in results
+    assert b"f(aaa, bbb)" in results
+
+
+def test_child_deletion_generates_runs_of_statements():
+    source = b"aa();\nbb();\ncc();\ndd();\n"
+    tree = parse_tree("javascript", source)
+    cuts = child_deletion_cuts(tree, source)
+    results = {apply_cuts(source, cut) for cut in cuts}
+    # A run of two adjacent statements is a single candidate.
+    assert b"aa();\ndd();\n" in results
+
+
+def test_child_deletion_skips_zero_width_nodes():
+    # `a :` parses as a labeled statement whose body is a zero-width
+    # empty_statement; deleting nothing is not a candidate.
+    source = b"a :"
+    tree = parse_tree("javascript", source)
+    for cut in child_deletion_cuts(tree, source):
+        for start, end in cut:
+            assert end > start
+
+
+# === lifting ===
+
+
+def test_lift_hoists_same_type_descendant():
+    source = b"if (a) { if (b) { body(); } }"
+    tree = parse_tree("javascript", source)
+    cuts = lift_cuts(tree, source)
+    results = {apply_cuts(source, cut) for cut in cuts}
+    assert b"if (b) { body(); }" in results
+
+
+def test_lift_promotes_named_children():
+    source = b"f((xyz));"
+    tree = parse_tree("javascript", source)
+    cuts = lift_cuts(tree, source)
+    results = {apply_cuts(source, cut) for cut in cuts}
+    assert b"f(xyz);" in results
+
+
+# === orphaned declarations ===
+
+GO_SOURCE = b"""package main
+
+import (
+\t"fmt"
+\t"strings"
+)
+
+func helper(x string) string {
+\treturn strings.ToUpper(x)
+}
+
+func main() {
+\tfmt.Println(helper("hi"))
+}
+"""
+
+
+def test_orphan_cuts_delete_function_along_with_its_only_import():
+    tree = parse_tree("go", GO_SOURCE)
+    cuts = orphaned_declaration_cuts(tree, GO_SOURCE)
+    results = {apply_cuts(GO_SOURCE, cut) for cut in cuts}
+    # Deleting helper() orphans the "strings" import, so a joint
+    # candidate for both must exist.
+    joint = [r for r in results if b"strings" not in r and b"fmt" in r]
+    assert joint
+
+
+def test_orphan_cuts_never_delete_the_package_clause():
+    tree = parse_tree("go", GO_SOURCE)
+    cuts = orphaned_declaration_cuts(tree, GO_SOURCE)
+    for cut in cuts:
+        assert b"package" in apply_cuts(GO_SOURCE, cut)
+
+
+def test_orphan_cuts_ignore_non_import_clauses_containing_use():
+    # Go's range_clause contains "use" as a substring of its node type;
+    # nodes inside it must not be treated as import entries.
+    source = (
+        b"package main\n"
+        b"func f(items []int) {\n"
+        b"\tfor _, v := range items {\n"
+        b"\t\tprintln(v)\n"
+        b"\t}\n"
+        b"}\n"
+    )
+    tree = parse_tree("go", source)
+    cuts = orphaned_declaration_cuts(tree, source)
+    for cut in cuts:
+        result = apply_cuts(source, cut)
+        # The blank identifier must never be deleted on its own (that
+        # would leave `for , v :=` behind).
+        assert b"for ," not in result
+
+
+def test_orphan_names_ignore_empty_string_literals():
+    # The empty string in the var declaration contributes no name, so
+    # deleting main() leaves the var orphaned and jointly deletable.
+    source = b'package main\nvar sentinel = ""\nfunc main() { _ = sentinel }\n'
+    tree = parse_tree("go", source)
+    cuts = orphaned_declaration_cuts(tree, source)
+    results = {apply_cuts(source, cut) for cut in cuts}
+    assert b"package main\n\n\n" in results
+
+
+def test_orphan_cuts_empty_when_there_are_no_declarations():
+    source = b"package main\n"
+    tree = parse_tree("go", source)
+    assert orphaned_declaration_cuts(tree, source) == []
+
+
+# === substitutions ===
+
+
+def test_substitutes_minimal_same_type_text():
+    source = b"if (aaaa) { long_call(1, 2, 3); } else { ok(); }"
+    tree = parse_tree("javascript", source)
+    subs = minimal_substitutions(tree, source)
+    results = set()
+    for patch in subs:
+        for start, end, replacement in patch:
+            results.add(source[:start] + replacement + source[end:])
+    # The larger call expression can be replaced by the smaller one.
+    assert b"if (aaaa) { ok(); } else { ok(); }" in results
+
+
+def test_substitutions_empty_for_empty_source():
+    tree = parse_tree("javascript", b"")
+    assert minimal_substitutions(tree, b"") == []
+
+
+# === passes ===
+
+
+def test_treesitter_passes_are_named_after_the_language():
+    passes = treesitter_passes("go")
+    names = [p.__name__ for p in passes]
+    assert names
+    for name in names:
+        assert name.startswith("treesitter(go)/")
+
+
+def simulate_go_unused_import_rule(source: bytes) -> bool:
+    """Textual approximation of the Go compiler's unused-import rule."""
+    lines = source.split(b"\n")
+    imports = [
+        line.strip().strip(b'"')
+        for line in lines
+        if line.strip().startswith(b'"') or line.strip().startswith(b'import "')
+    ]
+    body = b"\n".join(line for line in lines if not line.strip().startswith(b'"'))
+    return all(name.split(b"/")[-1] + b"." in body for name in imports)
+
+
+def test_pass_deletes_function_and_orphaned_import_together():
+    initial = GO_SOURCE
+
+    def is_interesting(source: bytes) -> bool:
+        if b"fmt.Println" not in source:
+            return False
+        return simulate_go_unused_import_rule(source)
+
+    assert is_interesting(initial)
+    result = reduce_with(treesitter_passes("go"), initial, is_interesting)
+    # helper and the strings import can only go together; neither
+    # single deletion is interesting on its own.
+    assert b"strings" not in result
+    assert b"helper" not in result
+    assert b"fmt.Println" in result
+
+
+def test_pass_lifts_nested_conditionals():
+    initial = b"if (a) { if (b) { magic(); } }"
+
+    def is_interesting(source: bytes) -> bool:
+        return b"magic()" in source
+
+    result = reduce_with(treesitter_passes("javascript"), initial, is_interesting)
+    # Leading whitespace is outside the root node's span, so these
+    # passes cannot remove it; the byte-level passes handle that.
+    assert result.strip() == b"magic()"
+
+
+def test_passes_no_op_on_unparseable_candidates():
+    # tree-sitter parses anything (with ERROR nodes), so passes should
+    # still run and just fail to find useful candidates.
+    initial = b"}}}\x00\xff{{{"
+
+    def is_interesting(source: bytes) -> bool:
+        return source == initial
+
+    result = reduce_with(treesitter_passes("go"), initial, is_interesting)
+    assert result == initial
+
+
+# === reducer wiring ===
+
+
+def test_shrinkray_includes_treesitter_passes_when_language_set():
+    async def is_interesting(data: bytes) -> bool:
+        return True
+
+    problem = BasicReductionProblem(
+        b"package main\n",
+        is_interesting,
+        work=WorkContext(parallelism=1),
+    )
+    reducer = ShrinkRay(target=problem, treesitter_language="go")
+    names = {p.__name__ for p in reducer.great_passes}
+    assert any(name.startswith("treesitter(go)/") for name in names)
+
+
+def test_shrinkray_has_no_treesitter_passes_without_language():
+    async def is_interesting(data: bytes) -> bool:
+        return True
+
+    problem = BasicReductionProblem(
+        b"package main\n",
+        is_interesting,
+        work=WorkContext(parallelism=1),
+    )
+    reducer = ShrinkRay(target=problem)
+    names = {p.__name__ for p in reducer.great_passes}
+    assert not any(name.startswith("treesitter(") for name in names)

--- a/tests/test_treesitter_passes.py
+++ b/tests/test_treesitter_passes.py
@@ -172,11 +172,11 @@ def test_orphan_names_from_dotted_import_paths():
     # The usable name of this import ("yaml.v2") is not a plain word
     # token, exercising the slow-path occurrence search.
     source = (
-        b'package main\n'
+        b"package main\n"
         b'import "gopkg.in/yaml.v2"\n'
         b'import "fmt"\n'
-        b'func dump(v any) { fmt.Println(yaml.Marshal(v)) }\n'
-        b'func main() { dump(1) }\n'
+        b"func dump(v any) { fmt.Println(yaml.Marshal(v)) }\n"
+        b"func main() { dump(1) }\n"
     )
     tree = parse_tree("go", source)
     cuts = orphaned_declaration_cuts(tree, source)
@@ -204,8 +204,7 @@ def test_orphan_cascade_collects_transitively_dead_declarations():
     cuts = orphaned_declaration_cuts(tree, source)
     results = {apply_cuts(source, cut) for cut in cuts}
     assert any(
-        b"util" not in r and b"helper" not in r and b"unused0" in r
-        for r in results
+        b"util" not in r and b"helper" not in r and b"unused0" in r for r in results
     )
 
 
@@ -214,10 +213,10 @@ def test_orphan_extent_can_end_inside_an_anonymous_token():
     # occurrence outside the import is a bare keyword token; the
     # covering-chain walk descends into that unnamed token.
     source = (
-        b'package main\n'
+        b"package main\n"
         b'import "x/return"\n'
-        b'func f() int { return 2 }\n'
-        b'func main() { println(f()) }\n'
+        b"func f() int { return 2 }\n"
+        b"func main() { println(f()) }\n"
     )
     tree = parse_tree("go", source)
     cuts = orphaned_declaration_cuts(tree, source)

--- a/tests/test_treesitter_passes.py
+++ b/tests/test_treesitter_passes.py
@@ -1,5 +1,6 @@
 from shrinkray.passes.treesitter import (
     EXTENSION_LANGUAGES,
+    _names_mentioned,
     child_deletion_cuts,
     language_for_filename,
     lift_cuts,
@@ -165,6 +166,71 @@ def test_orphan_names_ignore_empty_string_literals():
     cuts = orphaned_declaration_cuts(tree, source)
     results = {apply_cuts(source, cut) for cut in cuts}
     assert b"package main\n\n\n" in results
+
+
+def test_orphan_names_from_dotted_import_paths():
+    # The usable name of this import ("yaml.v2") is not a plain word
+    # token, exercising the slow-path occurrence search.
+    source = (
+        b'package main\n'
+        b'import "gopkg.in/yaml.v2"\n'
+        b'import "fmt"\n'
+        b'func dump(v any) { fmt.Println(yaml.Marshal(v)) }\n'
+        b'func main() { dump(1) }\n'
+    )
+    tree = parse_tree("go", source)
+    cuts = orphaned_declaration_cuts(tree, source)
+    results = {apply_cuts(source, cut) for cut in cuts}
+    # Deleting the dump function orphans both imports (the call site in
+    # main survives; only the definition and imports are deleted).
+    assert any(
+        b"func dump" not in r and b"import" not in r and b"func main" in r
+        for r in results
+    )
+
+
+def test_orphan_cascade_collects_transitively_dead_declarations():
+    # Deleting the const statement orphans helper; helper's body plus
+    # the const statement together hold every reference to util, so the
+    # cascade collects util as well even though no single node covers
+    # all of util's references.
+    source = (
+        b"function util(x) { return x + 1; }\n"
+        b"function helper(y) { return util(y); }\n"
+        b"function unused0() {}\n"
+        b"const out = helper(util(2));\n"
+    )
+    tree = parse_tree("javascript", source)
+    cuts = orphaned_declaration_cuts(tree, source)
+    results = {apply_cuts(source, cut) for cut in cuts}
+    assert any(
+        b"util" not in r and b"helper" not in r and b"unused0" in r
+        for r in results
+    )
+
+
+def test_orphan_extent_can_end_inside_an_anonymous_token():
+    # The import's usable name is the keyword `return`, whose only
+    # occurrence outside the import is a bare keyword token; the
+    # covering-chain walk descends into that unnamed token.
+    source = (
+        b'package main\n'
+        b'import "x/return"\n'
+        b'func f() int { return 2 }\n'
+        b'func main() { println(f()) }\n'
+    )
+    tree = parse_tree("go", source)
+    cuts = orphaned_declaration_cuts(tree, source)
+    results = {apply_cuts(source, cut) for cut in cuts}
+    assert any(b"import" not in r and b"func main" in r for r in results)
+
+
+def test_names_mentioned_handles_wordless_strings():
+    source = b'x = "-";\n'
+    tree = parse_tree("javascript", source)
+    names = _names_mentioned(tree.root_node, source)
+    assert b"-" in names
+    assert b"x" in names
 
 
 def test_orphan_cuts_empty_when_there_are_no_declarations():

--- a/uv.lock
+++ b/uv.lock
@@ -793,6 +793,8 @@ dependencies = [
     { name = "libcst" },
     { name = "textual" },
     { name = "textual-plotext" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-language-pack" },
     { name = "trio" },
 ]
 
@@ -842,6 +844,8 @@ requires-dist = [
     { name = "syrupy", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "textual", specifier = ">=8.0.0" },
     { name = "textual-plotext", specifier = ">=1.0.1" },
+    { name = "tree-sitter", specifier = ">=0.26.0" },
+    { name = "tree-sitter-language-pack", specifier = ">=1.12.2" },
     { name = "trio", specifier = ">=0.28.0" },
 ]
 provides-extras = ["dev"]
@@ -904,6 +908,55 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9a/b0/e4e0f38df057db778252db0dd2c08522d7222b8537b6a0181d797b9044bd/textual_plotext-1.0.1.tar.gz", hash = "sha256:836f53a3316756609e194129a35c2875638e7958c261f541e0a794f7c98011be", size = 16489, upload-time = "2024-11-30T19:25:56.625Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/53/fba7da208f9d3f59254413660fa0aa6599f2aca806f3ae356670455fd4ea/textual_plotext-1.0.1-py3-none-any.whl", hash = "sha256:6b6bfd00b29f121ddf216eaaf9bdac9d688ed72f40028484d279a10cbbb169ed", size = 16558, upload-time = "2024-11-30T19:25:32.208Z" },
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/03/5600b84aff2e6c4fe80cfebb4063fe2f50299521befe5f6092ab8c082f4a/tree_sitter-0.26.0.tar.gz", hash = "sha256:b40c219edccc4564530c96f8f1556f6202b37cda964d1cbd7bd2b7e68b40a245", size = 191423, upload-time = "2026-06-30T12:14:27.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/ca/565702c44815393e3a973552ad546db4e5ca081ca8698640b4e93d809f51/tree_sitter-0.26.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6cb2bd20efb2544c19ac54486ab7cb8ec7b36f913bbe1ce95df84acb96743d9c", size = 148934, upload-time = "2026-06-30T12:14:01.188Z" },
+    { url = "https://files.pythonhosted.org/packages/54/6f/8bb61957f16ec1b1d92410a006cdc84a952b6352a7313b2ad299f2d21484/tree_sitter-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:918d89529786873f0982a0f59c2a303cd065fbfd1b903d71a8e4e1584f67b42e", size = 140820, upload-time = "2026-06-30T12:14:02.087Z" },
+    { url = "https://files.pythonhosted.org/packages/78/0a/8a6f08559182643a814a4ab559948ae817b2851890fd9b995a4fff6541ce/tree_sitter-0.26.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30a88be89ff1f2755297f81e8080d88b795dd98720c3f9fa2acf93873182cc95", size = 638844, upload-time = "2026-06-30T12:14:03.428Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2f/6e6781b31677231366cb3cf27bc8269157f6d4b03c9032865a4f5f2bbe7e/tree_sitter-0.26.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a6b333b0282d8bb0af741f9b018bd2523d4eecb2686bf6717066a625fecfaa4", size = 667487, upload-time = "2026-06-30T12:14:04.669Z" },
+    { url = "https://files.pythonhosted.org/packages/02/0b/0483078c8567445557a7015b0e5b187f6d7d4fda73464df9c4bdea7f7f3c/tree_sitter-0.26.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3f3c44339dd34fe8eb2b8d5aa7610660499a795f70376b130bbee7a437337280", size = 647975, upload-time = "2026-06-30T12:14:05.797Z" },
+    { url = "https://files.pythonhosted.org/packages/27/68/da83ca72c984e96ab4eb3bee0db1a6ffb5de1c8c455f92bd9f420cde7f0e/tree_sitter-0.26.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:94550e13b6ae576969da40246f4c4abb206380b5375ad43f26dd9151d55438e3", size = 665018, upload-time = "2026-06-30T12:14:07.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/36/4d67927fd47b89af4a00f65f55a7370e28778cd50e972c2430487e3ecc27/tree_sitter-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:ca89e361a276dbc934b28a43dd881199e25d34ff5493ee0ce45f3c52a6124a37", size = 129619, upload-time = "2026-06-30T12:14:08.373Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/72/cdefad523eb78710679c6da6a79e3d90f5afd32b1c6aa5a17bac7eef99f6/tree_sitter-0.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:bc6cb01d5ee75c85424aa1f1c72a82d8f07fd52539a0f3c4a6ed3e8721079b84", size = 116545, upload-time = "2026-06-30T12:14:09.273Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/b0/465257cf8f972ad9f9812ec1cbaa8ec210ebebb601ade9a15881aa2436b4/tree_sitter-0.26.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ed0889dbed843ce45ede9f5169c0b2dea2222f12685844a03fadb81f12705867", size = 148893, upload-time = "2026-06-30T12:14:10.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ec/19d093e854b45e807fecfdd26105c266f43aeecc39c4dc97992a7074ad5a/tree_sitter-0.26.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6189c6c340c7384357711e3d92645e96bfb79f7a502f86de1ebdb23eb43f7dab", size = 140829, upload-time = "2026-06-30T12:14:11.626Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ee/87e74671ed63a837e7a1f17ab94aa3913871e033b27523d8e7b83d6f7ad0/tree_sitter-0.26.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8ff2e0750b7daa722302838356d7b65e303829b7eb73c915df127ddba115e1d1", size = 639334, upload-time = "2026-06-30T12:14:12.836Z" },
+    { url = "https://files.pythonhosted.org/packages/66/e7/f7e04cd9dff6b6ac0adf23922796fbc76accd4cf4bcda50542748d485679/tree_sitter-0.26.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7075ef857ef86f327dbb72d1e2574dda78db5754b3a1fca6506acd7fe5d561a7", size = 668102, upload-time = "2026-06-30T12:14:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/90/0bfb16b7894fea728c774a89d5af421a9368a2f913bbd4e8dcab7caaecfb/tree_sitter-0.26.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:26c996c1edfee86e977bb3f5462e74fcec0d0b0db1e85a3c475875763caa03be", size = 648560, upload-time = "2026-06-30T12:14:15.302Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/e6/0fe05ba396e9623b0ae40ccf34171336b8701ec8d7bd0ee9f5224d638665/tree_sitter-0.26.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:00289bfe7978f3e0dc0ce69813a20fa9f44ea4c100b3ec62043e5eb74ccfc3a2", size = 665121, upload-time = "2026-06-30T12:14:16.403Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/a944b1ca35bed6068dc84a9967aaf3049d8cc0b7a36179eea8787270a6ab/tree_sitter-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:93e220cab7e6a823efeb2046c49171427de92ef71c7c681c01820d14d8d3721f", size = 129615, upload-time = "2026-06-30T12:14:17.463Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ef/c7ca48293580d2249f36940c4eed5b4ddeb9ce75baf9a4ef30621987e0c7/tree_sitter-0.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:b31a8195d2f224224c530ac814632d98c1dcc123d227442c07c736e86b70d564", size = 116525, upload-time = "2026-06-30T12:14:18.53Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/7a/4d84e6f6ae2c3e757490dd84de251712c31e293dfe31f28da1ec019cefa2/tree_sitter-0.26.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5a3c93a352b7e6f70f73e121bbfa2d0117ba7478bd51114ed35c91b0b78814fa", size = 148901, upload-time = "2026-06-30T12:14:19.452Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d9/efe62ec65dc9d096e834d27b8c058127e2146e42ff3380b822a233f016a6/tree_sitter-0.26.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5fc2f41bf246ff2f70a9cc3690be35ec7580a4923151873d898c8bcb1a4503d3", size = 140805, upload-time = "2026-06-30T12:14:20.478Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2c/c82326b7b97e3c485c18679883b16f89e5e913c639d3b219d3da70c9e67e/tree_sitter-0.26.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8ea92a255c91671a7ec4625aba3ab7bb5220c423630ffbf83c45d7312abe084", size = 640586, upload-time = "2026-06-30T12:14:21.527Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/7a/f56e7d8282859452611024c7cbc623bfba5b24b8cb9b8f8bc88c5219fe9a/tree_sitter-0.26.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f665510f0fcf4636fb9696f1f7853bed7a3bd764b7bb0cb8494e619c14ed5a0c", size = 668300, upload-time = "2026-06-30T12:14:22.728Z" },
+    { url = "https://files.pythonhosted.org/packages/91/51/240ee81b9d5e9ca0a6cb1528e8605ffa70ab58c89ce126631be96d3e4bae/tree_sitter-0.26.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:253df7ab82cc0a9d311cd65f06e9f99fb3eac55996ae9fc94da22f123a861b90", size = 649627, upload-time = "2026-06-30T12:14:23.819Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/54/760035cefedf9eb44f0f84c4ac22f1322e73155853e272576ee876336312/tree_sitter-0.26.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ff80d4833d330a73184a3ac5132abe93c575d2dea31975c6f15c0d21fef238aa", size = 664885, upload-time = "2026-06-30T12:14:25.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1b/0b36fe2a984ecedc4ce6aefd5d56447a6626a8e9b595c4e48658510ce8f8/tree_sitter-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:a4033fecc8f606c7f2e8b8014d0057b74668a7f0152763606f7bc25c5f9ec64c", size = 132688, upload-time = "2026-06-30T12:14:26.106Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/74/ebc041a13fbf40144afdb0d4b447e48e0b4012ca866c63de8b48f801f0c1/tree_sitter-0.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:823251c4b6725a7c03ed497a339135ede7ae4bdde75bb8be7ef5e305aeb4ff52", size = 120287, upload-time = "2026-06-30T12:14:26.991Z" },
+]
+
+[[package]]
+name = "tree-sitter-language-pack"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tree-sitter" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/ba/286954ebe16f106967c1c316679dab95153eaf5db5ac505fd7cf6aee5250/tree_sitter_language_pack-1.12.2.tar.gz", hash = "sha256:c5b8428a2fd4bb3eeeac73056fe0c4af6a5d67a20b8317e9eab84f88bf62de5a", size = 81210, upload-time = "2026-07-02T05:25:16.823Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/e0/bc99ea0d06db11e45289a8a3ab43929ca25f7ead57af8398135ee03fe09f/tree_sitter_language_pack-1.12.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a7b5c2b4d3124adc8e5b960c55401f1340a515122ca607e6f375a24dfa3ee5da", size = 2121958, upload-time = "2026-07-02T05:25:06.602Z" },
+    { url = "https://files.pythonhosted.org/packages/39/c6/0205ee11715d76a5c1674d7541c057f19c4d6af8ce43b53f90d265de7ca9/tree_sitter_language_pack-1.12.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:bbc1925e4ab74d8854aabb4ab92caf2a9f234dc85c639748795aa905ee4080b1", size = 2011075, upload-time = "2026-07-02T05:25:08.699Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b0/517928ef68fc832bea09d37c98a9813bbd51c44461989490b754e655acbf/tree_sitter_language_pack-1.12.2-cp310-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:d279f035ffe4e954479a86b50b99bc9458430ef587c114d515c4fe74b8596deb", size = 2170162, upload-time = "2026-07-02T05:25:10.393Z" },
+    { url = "https://files.pythonhosted.org/packages/48/8b/4d5725d3a120e7662f609f3cbdd7816f93d4c3c720f327001140bf815f87/tree_sitter_language_pack-1.12.2-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:3a59156882d7180a7833577c269cd7dc9b4c36263659cf96df95169de515018e", size = 2282350, upload-time = "2026-07-02T05:25:11.926Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/10/293bd8f7efe8f47dd0ad3e03875f0f7b01caf67e6c8b52a1254f99ab4da3/tree_sitter_language_pack-1.12.2-cp310-abi3-win_amd64.whl", hash = "sha256:f587da7195f7a17a09f06d10a8f9e38102a799b693f81cdea6df53587f23ef41", size = 2055338, upload-time = "2026-07-02T05:25:13.512Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/62/28a14cc28ed4b790edc865492b566bb22f7f28ed387419655fa38bb2899e/tree_sitter_language_pack-1.12.2-cp310-abi3-win_arm64.whl", hash = "sha256:5b651701387d26ae3bbc93eb8617d2fae26ce459f267ea27632598201ccb2055", size = 1967260, upload-time = "2026-07-02T05:25:15.4Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<details><summary>AI-generated description (Claude)</summary>

This implements the suggestion from #59. Shrink ray now runs grammar-aware passes for any language with a tree-sitter grammar (selected by file extension via tree-sitter-language-pack), alongside the existing byte-level passes. tree-sitter can't generate code, but its nodes carry byte offsets, so deletion, hoisting, same-kind substitution, and — the genuinely new capability — deleting dead declarations *together with the imports only they used* all express as ordinary Cuts/Replacements patches. That coupled deletion is what unblocks languages like Go, where unused imports are hard errors and no single-cut pass can make progress on dead code.

To evaluate it I added three corpus entries for real crash bugs in languages shrink ray had no dedicated passes for (a go 1.18 ICE, a rustc 1.94 ICE, and a terser 5.15.1 crash), all reproducible natively with sub-second oracles. Against the pre-tree-sitter baseline: go 317 → 220 bytes, rust 185 → 141, terser unchanged at 24, and every entry converged in roughly half the wall-clock time. Full analysis, including what still can't be removed and why, is in `evaluation/RESULTS.md`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)