### PR TITLE
External reducers: run the Python reducer out-of-process, add --reduce-with

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+- Added `--reduce-with '<command>'` (repeatable) to plug in your own external
+  reducer: a program that reduces the test case by talking to Shrink Ray over a
+  small JSON protocol on its stdin/stdout.
+- The built-in Python reducer now runs as one of these external reducers. Use
+  `--no-python-reducer` to turn it off. When history is enabled, each reducer's
+  log is written under the run's `.shrinkray` directory.
+- Reduction can now replace an identifier with `0` (e.g. `assert x` becomes
+  `assert 0`), which drops dependencies and unblocks further reduction such as
+  deleting the definition the name referred to.

--- a/notes/external-reducers.md
+++ b/notes/external-reducers.md
@@ -1,0 +1,58 @@
+# External Reducers
+
+An **external reducer** is a subprocess that reduces a test case by talking to
+shrink ray over a small line-based protocol. It lets reduction logic live
+outside the main process — used for the built-in libcst Python reducer, and
+available to users via `--reduce-with`.
+
+## Why
+
+- **Isolation**: heavyweight or crash-prone reducers (libcst, third-party tools)
+  run in their own process instead of the reducer's trio event loop.
+- **Extensibility**: users can plug in their own reducers in any language
+  without touching shrink ray, by implementing the protocol.
+
+## The protocol
+
+Newline-delimited JSON on the reducer's stdin/stdout; stderr is logged to a file
+(under `.shrinkray/<run>/reducers/` when history is enabled). Test-case content
+is base64-encoded so arbitrary bytes survive JSON.
+
+- **query** (reducer → shrink ray): `{"content": <base64>}` — a candidate the
+  reducer wants evaluated.
+- **feedback** (shrink ray → reducer): `{"content": <base64>, "interesting": <bool>}`.
+
+Sequence:
+
+1. On launch shrink ray sends one feedback message: the initial test case, with
+   `interesting` true. This is the reducer's starting point.
+2. The reducer emits queries. Shrink ray runs its interestingness test on each
+   (up to `parallelism` concurrently) and replies with a feedback message
+   echoing the query's `content` plus the boolean result.
+3. When the current test case changes (a reduction is adopted, possibly
+   reformatted, or another pass advances it), shrink ray sends an unsolicited
+   feedback message with the new content. The reducer distinguishes a reply
+   from an update by whether the `content` matches an outstanding query.
+4. The reducer exits when it has nothing left to try. Shrink ray also terminates
+   it if it emits no query for a timeout (default 60s).
+
+Because queries can be pipelined and answered concurrently, a reducer keeps its
+own parallelism to keep shrink ray busy. Shrink ray passes its parallelism to
+the subprocess in `SHRINKRAY_REDUCER_PARALLELISM`.
+
+## Code layout
+
+- `shrinkray/reducers/protocol.py` — message encode/decode and a line reader.
+- `shrinkray/reducers/driver.py` — `RemoteReductionProblem` (a
+  `ReductionProblem` whose `is_interesting` is answered over the protocol) and
+  `run_reducer`, which drives ordinary reduction passes against it. This is how
+  a pass written against `ReductionProblem` runs unchanged inside a reducer
+  subprocess: only the problem it runs against changes.
+- `shrinkray/reducers/python.py` — the built-in Python reducer's entry point.
+- `shrinkray/passes/external.py` — the shrink-ray side: `drive_external_reducer`
+  (the protocol loop) and `external_reducer`, which wraps a command line as a
+  `ReductionPass`, managing the subprocess, its log file, and the timeout.
+
+`ShrinkRay` builds its external reducer passes in `build_external_reducer_passes`:
+the built-in Python reducer (when enabled and the input looks like Python)
+followed by any user `--reduce-with` reducers.

--- a/notes/external-reducers.md
+++ b/notes/external-reducers.md
@@ -18,23 +18,38 @@ Newline-delimited JSON on the reducer's stdin/stdout; stderr is logged to a file
 (under `.shrinkray/<run>/reducers/` when history is enabled). Test-case content
 is base64-encoded so arbitrary bytes survive JSON.
 
-- **query** (reducer → shrink ray): `{"content": <base64>}` — a candidate the
-  reducer wants evaluated.
-- **feedback** (shrink ray → reducer): `{"content": <base64>, "interesting": <bool>}`.
+Shrink ray → reducer:
+
+- **reduce** `{"reduce": <base64>}` — "reduce this test case to a fixpoint and
+  tell me when you are idle".
+- **feedback** `{"content": <base64>, "interesting": <bool>}` — the result for a
+  query, or an unsolicited update to the current test case.
+
+Reducer → shrink ray:
+
+- **query** `{"content": <base64>}` — a candidate it wants evaluated.
+- **idle** `{"idle": true}` — "I have reached a fixpoint for the current reduce
+  request".
 
 Sequence:
 
-1. On launch shrink ray sends one feedback message: the initial test case, with
-   `interesting` true. This is the reducer's starting point.
+1. Shrink ray sends a reduce request with the current test case. (The first
+   message the reducer receives is always a reduce request.)
 2. The reducer emits queries. Shrink ray runs its interestingness test on each
    (up to `parallelism` concurrently) and replies with a feedback message
-   echoing the query's `content` plus the boolean result.
-3. When the current test case changes (a reduction is adopted, possibly
-   reformatted, or another pass advances it), shrink ray sends an unsolicited
-   feedback message with the new content. The reducer distinguishes a reply
-   from an update by whether the `content` matches an outstanding query.
-4. The reducer exits when it has nothing left to try. Shrink ray also terminates
-   it if it emits no query for a timeout (default 60s).
+   echoing the query's `content` plus the boolean result. The reducer adopts a
+   candidate as its new current when the reply says it is interesting.
+3. When the reducer can make no more progress it sends idle; shrink ray's pass
+   returns, leaving the reducer alive.
+4. On a later invocation shrink ray sends another reduce request (with the
+   possibly-changed current) and the reducer works again. It exits only when
+   shrink ray closes its stdin.
+
+Keeping the reducer alive across reduce requests means expensive startup (such
+as importing libcst) is paid once. A reducer that instead **exits** at a
+fixpoint (closing its stdout) is also supported: shrink ray relaunches it next
+time. Shrink ray also terminates a reducer that produces no output for a timeout
+(default 60s).
 
 Because queries can be pipelined and answered concurrently, a reducer keeps its
 own parallelism to keep shrink ray busy. Shrink ray passes its parallelism to

--- a/notes/external-reducers.md
+++ b/notes/external-reducers.md
@@ -20,35 +20,38 @@ is base64-encoded so arbitrary bytes survive JSON.
 
 Shrink ray → reducer:
 
-- **reduce** `{"reduce": <base64>}` — "reduce this test case to a fixpoint and
-  tell me when you are idle".
-- **feedback** `{"content": <base64>, "interesting": <bool>}` — the result for a
-  query, or an unsolicited update to the current test case.
+- **feedback** `{"content": <base64>, "interesting": <bool>}` — either the result
+  for a query the reducer made, or (when the content matches no outstanding
+  query) a test case for it to work on.
 
 Reducer → shrink ray:
 
 - **query** `{"content": <base64>}` — a candidate it wants evaluated.
-- **idle** `{"idle": true}` — "I have reached a fixpoint for the current reduce
-  request".
+- **idle** `{"idle": true}` — "I have reached a fixpoint for the current test
+  case".
+
+There is only one message type in each direction plus `idle`. The reducer tells
+a reply from a fresh test case by content: a feedback message echoing a query it
+made is that query's result; any other feedback is a new current test case.
 
 Sequence:
 
-1. Shrink ray sends a reduce request with the current test case. (The first
-   message the reducer receives is always a reduce request.)
+1. Shrink ray sends the current test case as feedback (`interesting` true). The
+   first message the reducer receives is one of these.
 2. The reducer emits queries. Shrink ray runs its interestingness test on each
    (up to `parallelism` concurrently) and replies with a feedback message
    echoing the query's `content` plus the boolean result. The reducer adopts a
    candidate as its new current when the reply says it is interesting.
 3. When the reducer can make no more progress it sends idle; shrink ray's pass
    returns, leaving the reducer alive.
-4. On a later invocation shrink ray sends another reduce request (with the
-   possibly-changed current) and the reducer works again. It exits only when
-   shrink ray closes its stdin.
+4. On a later invocation shrink ray sends the (possibly-changed) current test
+   case as another feedback message, and the reducer works again. It exits only
+   when shrink ray closes its stdin.
 
-Keeping the reducer alive across reduce requests means expensive startup (such
-as importing libcst) is paid once. A reducer that instead **exits** at a
-fixpoint (closing its stdout) is also supported: shrink ray relaunches it next
-time. Shrink ray also terminates a reducer that produces no output for a timeout
+Keeping the reducer alive across test cases means expensive startup (such as
+importing libcst) is paid once. A reducer that instead **exits** at a fixpoint
+(closing its stdout) is also supported: shrink ray relaunches it next time.
+Shrink ray also terminates a reducer that produces no output for a timeout
 (default 60s).
 
 Because queries can be pipelined and answered concurrently, a reducer keeps its

--- a/notes/reduction-passes.md
+++ b/notes/reduction-passes.md
@@ -20,6 +20,8 @@ Reduction passes for "things that look like programming languages" - text with c
 
 Python-specific AST-aware reductions using libcst. Includes passes for lifting indented constructs (replacing `if`/`while`/`try`/`with` blocks with their bodies), replacing indented block bodies with `...`, replacing statements with `pass`, stripping type annotations, and deleting statements. These understand Python syntax and produce valid Python output.
 
+These passes are not run in-process. Instead they run inside a subprocess as an **external reducer** (see `notes/external-reducers.md`): `ShrinkRay` launches `python -m shrinkray.reducers.python`, which runs `PYTHON_PASSES` against a `RemoteReductionProblem` that answers `is_interesting` over the external-reducer protocol. This keeps libcst (and any future heavyweight reducers) out of the main process while preserving parallelism.
+
 ### json.py
 
 JSON-specific passes. Provides `delete_identifiers` for recursively removing keys from JSON objects throughout the structure (built on the `DeleteIdentifiers` patch type).

--- a/src/shrinkray/__main__.py
+++ b/src/shrinkray/__main__.py
@@ -15,6 +15,7 @@ from shrinkray.cli import (
     InputType,
     UIType,
     validate_command,
+    validate_commands,
     validate_ui,
 )
 from shrinkray.formatting import determine_formatter_command
@@ -241,6 +242,29 @@ If --no-history is passed, also-interesting recording is disabled unless
 cases are recorded, not reductions). Set to 0 to disable. Default: 101.
 """.strip(),
 )
+@click.option(
+    "--reduce-with",
+    "reduce_with",
+    multiple=True,
+    callback=validate_commands,
+    help="""
+An external reducer to run as a reduction pass, specified as a command. May be
+passed more than once to run several reducers.
+
+An external reducer is a program that shrink ray drives over its stdin/stdout
+using a small JSON protocol (its stderr is logged to the .shrinkray directory).
+See the documentation for the protocol.
+""".strip(),
+)
+@click.option(
+    "--python-reducer/--no-python-reducer",
+    default=True,
+    help="""
+Run shrink ray's built-in libcst-based Python reducer (as an external reducer)
+when the input looks like Python. Enabled by default; use --no-python-reducer
+to disable it.
+""".strip(),
+)
 @click.argument("test", callback=validate_command)
 @click.argument(
     "filename",
@@ -264,6 +288,8 @@ def main(
     theme: str,
     history: bool,
     also_interesting: int,
+    reduce_with: list[list[str]],
+    python_reducer: bool,
 ) -> None:
     if timeout is not None and timeout <= 0:
         timeout = float("inf")
@@ -360,6 +386,8 @@ def main(
         "volume": volume,
         "history_enabled": history,
         "also_interesting_code": also_interesting_code,
+        "external_reducers": reduce_with,
+        "python_reducer": python_reducer,
     }
 
     state: ShrinkRayState[Any]
@@ -412,6 +440,8 @@ def main(
             theme=theme,  # type: ignore[arg-type]
             history_enabled=history,
             also_interesting_code=also_interesting_code,
+            external_reducers=reduce_with,
+            python_reducer=python_reducer,
         )
         return
 

--- a/src/shrinkray/cli.py
+++ b/src/shrinkray/cli.py
@@ -10,8 +10,12 @@ from typing import Any
 import click
 
 
-def validate_command(ctx: Any, param: Any, value: str) -> list[str]:
-    """Validate and resolve a command string."""
+def resolve_command(value: str) -> list[str]:
+    """Parse a command string into argv, resolving the executable on PATH.
+
+    Raises click.BadParameter if the command is empty, unparseable, or the
+    executable cannot be found.
+    """
     try:
         parts = shlex.split(value)
     except ValueError as e:
@@ -28,6 +32,19 @@ def validate_command(ctx: Any, param: Any, value: str) -> list[str]:
             raise click.BadParameter(f"{command}: command not found")
         command = os.path.abspath(what)
     return [command] + parts[1:]
+
+
+def validate_command(ctx: Any, param: Any, value: str) -> list[str]:
+    """Validate and resolve a single command string (click callback)."""
+    return resolve_command(value)
+
+
+def validate_commands(ctx: Any, param: Any, value: tuple[str, ...]) -> list[list[str]]:
+    """Validate and resolve a tuple of command strings (click callback).
+
+    Used for repeatable options like --reduce-with.
+    """
+    return [resolve_command(v) for v in value]
 
 
 class EnumChoice[EnumType: Enum](click.Choice):

--- a/src/shrinkray/passes/external.py
+++ b/src/shrinkray/passes/external.py
@@ -3,34 +3,37 @@
 An external reducer is a subprocess that shrink ray drives over the protocol in
 :mod:`shrinkray.reducers.protocol`. This module provides the shrink-ray side:
 
-- :func:`drive_external_reducer` runs the protocol over a pair of streams,
+- :func:`drive_external_reducer` runs one reduce request over a pair of streams,
   evaluating the reducer's queries with ``problem.is_interesting`` and feeding
   the results back. It is independent of process management so it can be tested
   directly.
-- :func:`external_reducer` wraps a command line as a :data:`ReductionPass`,
-  launching the subprocess, redirecting its stderr to a log file, and killing it
-  on completion, timeout, or cancellation.
+- :class:`ExternalReducerPass` wraps a command line as a reduction pass. It
+  keeps the subprocess alive across invocations (so expensive startup happens
+  once), redirects its stderr to a log file, and cleans it up on completion,
+  timeout, or cancellation.
+- :func:`external_reducer` is a thin constructor for :class:`ExternalReducerPass`.
 """
 
 import os
 import subprocess
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import IO
 
 import trio
 
-from shrinkray.passes.definitions import ReductionPass
 from shrinkray.problem import ReductionProblem
 from shrinkray.process import interrupt_wait_and_kill
 from shrinkray.reducers.protocol import (
+    Idle,
     LineReader,
-    decode_query,
     encode_feedback,
+    encode_reduce,
+    parse_from_reducer,
 )
 
 
-# If the reducer emits no query for this long, we assume it has wedged and
-# terminate it. Overridable per reducer.
+# If the reducer emits nothing for this long while working, we assume it has
+# wedged and terminate it. Overridable per reducer.
 DEFAULT_REDUCER_TIMEOUT = 60.0
 
 
@@ -38,56 +41,50 @@ async def drive_external_reducer(
     problem: ReductionProblem[bytes],
     *,
     send_stream: trio.abc.SendStream,
-    recv_stream: trio.abc.ReceiveStream,
+    reader: LineReader,
     timeout: float = DEFAULT_REDUCER_TIMEOUT,
     parallelism: int = 1,
-) -> None:
-    """Run the shrink-ray side of the external reducer protocol.
+) -> bool:
+    """Run one reduce request against an external reducer.
 
-    Sends the initial test case, then reads candidate queries from
-    ``recv_stream`` and answers them on ``send_stream``, running interestingness
-    tests up to ``parallelism`` at a time. Returns when the reducer closes
-    ``recv_stream`` (EOF) or when no query arrives for ``timeout`` seconds.
+    Sends the current test case as a reduce request, then answers the reducer's
+    queries (running interestingness tests up to ``parallelism`` at a time) until
+    the reducer reports idle. ``reader`` reads the reducer's output and is reused
+    across requests so buffered bytes are not lost.
+
+    Returns True if the reducer went idle (and is still alive), or False if it
+    exited (EOF) or timed out.
     """
-    reader = LineReader(recv_stream)
     send_lock = trio.Lock()
-    # The current test case as last advertised to the reducer. Whenever the real
-    # current test case moves ahead of this, we push an unsolicited update.
-    last_advertised = problem.current_test_case
 
-    async def send_feedback(content: bytes, interesting: bool) -> None:
-        try:
-            await send_stream.send_all(encode_feedback(content, interesting))
-        except (trio.BrokenResourceError, trio.ClosedResourceError):
-            # The reducer exited while we were replying; nothing more to say.
-            pass
+    async def send(data: bytes) -> None:
+        async with send_lock:
+            try:
+                await send_stream.send_all(data)
+            except (trio.BrokenResourceError, trio.ClosedResourceError):
+                # The reducer exited; nothing more to say.
+                pass
 
-    # Handshake: tell the reducer what it is starting from.
-    await send_feedback(problem.current_test_case, True)
+    await send(encode_reduce(problem.current_test_case))
 
     # A semaphore (not a CapacityLimiter) because it is acquired by the reader
-    # task but released by the handler task, and semaphore tokens are not bound
+    # loop but released by the handler task, and semaphore tokens are not bound
     # to the acquiring task.
     slots = trio.Semaphore(max(parallelism, 1))
 
     async def handle(candidate: bytes) -> None:
-        nonlocal last_advertised
         try:
             interesting = await problem.is_interesting(candidate)
-            async with send_lock:
-                await send_feedback(candidate, interesting)
-                current = problem.current_test_case
-                if current != last_advertised:
-                    last_advertised = current
-                    await send_feedback(current, True)
+            await send(encode_feedback(candidate, interesting))
         finally:
             slots.release()
 
+    idle = False
     async with trio.open_nursery() as nursery:
         while True:
-            # Acquire a slot before reading so that a flood of queries can't
-            # outrun our workers: once all slots are busy the pipe fills and the
-            # reducer blocks on its next send.
+            # Acquire a slot before reading so a flood of queries can't outrun
+            # our workers: once all slots are busy the pipe fills and the reducer
+            # blocks on its next send.
             await slots.acquire()
             line: bytes | None = None
             with trio.move_on_after(timeout) as scope:
@@ -102,19 +99,111 @@ async def drive_external_reducer(
                 slots.release()
                 continue
             try:
-                candidate = decode_query(line)
+                message = parse_from_reducer(line)
             except ValueError:
-                # Malformed line: ignore it rather than killing the reducer.
                 slots.release()
                 continue
-            nursery.start_soon(handle, candidate)
+            if isinstance(message, Idle):
+                slots.release()
+                idle = True
+                break
+            nursery.start_soon(handle, message.content)
         nursery.cancel_scope.cancel()
+    return idle
 
 
 async def _terminate(proc: trio.Process) -> None:
     """Shut down the reducer subprocess, killing its process group if needed."""
     with trio.CancelScope(shield=True):
         await interrupt_wait_and_kill(proc)
+
+
+class ExternalReducerPass:
+    """A reduction pass that reduces via a persistent external reducer subprocess.
+
+    The subprocess is launched on first use and kept alive across pass
+    invocations, so per-launch startup cost (such as importing libcst) is paid
+    once. It is torn down when the reducer exits, when a call is cancelled or
+    errors, or when :meth:`aclose` is called (by the reducer at the end of a
+    run).
+    """
+
+    def __init__(
+        self,
+        command: Sequence[str],
+        *,
+        log_file: str | os.PathLike[str] | None = None,
+        timeout: float = DEFAULT_REDUCER_TIMEOUT,
+        name: str | None = None,
+        extra_env: Mapping[str, str] | None = None,
+    ) -> None:
+        self._command = list(command)
+        self._log_file = log_file
+        self._timeout = timeout
+        self._extra_env = extra_env
+        self.__name__ = name or f"external:{os.path.basename(self._command[0])}"
+        self._proc: trio.Process | None = None
+        self._reader: LineReader | None = None
+        self._stderr_file: IO[bytes] | None = None
+
+    async def _launch(self, parallelism: int) -> None:
+        env = dict(os.environ)
+        env["SHRINKRAY_REDUCER_PARALLELISM"] = str(parallelism)
+        if self._extra_env is not None:
+            env.update(self._extra_env)
+
+        target = self._log_file if self._log_file is not None else os.devnull
+        stderr_file: IO[bytes] = open(target, "ab")
+        try:
+            proc = await trio.lowlevel.open_process(
+                self._command,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=stderr_file.fileno(),
+                env=env,
+                preexec_fn=os.setsid,
+            )
+        except BaseException:
+            stderr_file.close()
+            raise
+        assert proc.stdout is not None
+        self._proc = proc
+        self._reader = LineReader(proc.stdout)
+        self._stderr_file = stderr_file
+
+    async def __call__(self, problem: ReductionProblem[bytes]) -> None:
+        parallelism = problem.work.parallelism
+        try:
+            if self._proc is None:
+                await self._launch(parallelism)
+            assert self._proc is not None
+            assert self._proc.stdin is not None
+            assert self._reader is not None
+            alive = await drive_external_reducer(
+                problem,
+                send_stream=self._proc.stdin,
+                reader=self._reader,
+                timeout=self._timeout,
+                parallelism=parallelism,
+            )
+            if not alive:
+                await self._shutdown()
+        except BaseException:
+            await self._shutdown()
+            raise
+
+    async def _shutdown(self) -> None:
+        if self._proc is not None:
+            await _terminate(self._proc)
+            self._proc = None
+            self._reader = None
+        if self._stderr_file is not None:
+            self._stderr_file.close()
+            self._stderr_file = None
+
+    async def aclose(self) -> None:
+        """Terminate the reducer subprocess if it is still running."""
+        await self._shutdown()
 
 
 def external_reducer(
@@ -124,54 +213,23 @@ def external_reducer(
     timeout: float = DEFAULT_REDUCER_TIMEOUT,
     name: str | None = None,
     extra_env: Mapping[str, str] | None = None,
-) -> ReductionPass[bytes]:
+) -> ExternalReducerPass:
     """Build a reduction pass that reduces via an external reducer subprocess.
 
     Args:
         command: The command (argv) to launch the reducer.
         log_file: Path to append the reducer's stderr to. If None, stderr is
             discarded.
-        timeout: Seconds without a query before the reducer is terminated.
+        timeout: Seconds without output from a working reducer before it is
+            terminated.
         name: Name for the pass (used in stats/status). Defaults to the command
             basename.
         extra_env: Extra environment variables for the subprocess.
     """
-    command = list(command)
-    reducer_name = name or f"external:{os.path.basename(command[0])}"
-
-    async def run_external(problem: ReductionProblem[bytes]) -> None:
-        parallelism = problem.work.parallelism
-        env = dict(os.environ)
-        env["SHRINKRAY_REDUCER_PARALLELISM"] = str(parallelism)
-        if extra_env is not None:
-            env.update(extra_env)
-
-        if log_file is not None:
-            stderr_ctx: Any = open(log_file, "ab")
-        else:
-            stderr_ctx = open(os.devnull, "ab")
-
-        with stderr_ctx as stderr:
-            proc = await trio.lowlevel.open_process(
-                command,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=stderr.fileno(),
-                env=env,
-                preexec_fn=os.setsid,
-            )
-            try:
-                assert proc.stdin is not None
-                assert proc.stdout is not None
-                await drive_external_reducer(
-                    problem,
-                    send_stream=proc.stdin,
-                    recv_stream=proc.stdout,
-                    timeout=timeout,
-                    parallelism=parallelism,
-                )
-            finally:
-                await _terminate(proc)
-
-    run_external.__name__ = reducer_name
-    return run_external
+    return ExternalReducerPass(
+        command,
+        log_file=log_file,
+        timeout=timeout,
+        name=name,
+        extra_env=extra_env,
+    )

--- a/src/shrinkray/passes/external.py
+++ b/src/shrinkray/passes/external.py
@@ -27,7 +27,6 @@ from shrinkray.reducers.protocol import (
     Idle,
     LineReader,
     encode_feedback,
-    encode_reduce,
     parse_from_reducer,
 )
 
@@ -45,12 +44,13 @@ async def drive_external_reducer(
     timeout: float = DEFAULT_REDUCER_TIMEOUT,
     parallelism: int = 1,
 ) -> bool:
-    """Run one reduce request against an external reducer.
+    """Reduce the current test case with an external reducer, once.
 
-    Sends the current test case as a reduce request, then answers the reducer's
-    queries (running interestingness tests up to ``parallelism`` at a time) until
-    the reducer reports idle. ``reader`` reads the reducer's output and is reused
-    across requests so buffered bytes are not lost.
+    Hands the reducer the current test case (as a feedback message, which -
+    matching no query it made - it takes as a fresh test case to reduce), then
+    answers its queries (running interestingness tests up to ``parallelism`` at a
+    time) until it reports idle. ``reader`` reads the reducer's output and is
+    reused across calls so buffered bytes are not lost.
 
     Returns True if the reducer went idle (and is still alive), or False if it
     exited (EOF) or timed out.
@@ -65,7 +65,7 @@ async def drive_external_reducer(
                 # The reducer exited; nothing more to say.
                 pass
 
-    await send(encode_reduce(problem.current_test_case))
+    await send(encode_feedback(problem.current_test_case, True))
 
     # A semaphore (not a CapacityLimiter) because it is acquired by the reader
     # loop but released by the handler task, and semaphore tokens are not bound

--- a/src/shrinkray/passes/external.py
+++ b/src/shrinkray/passes/external.py
@@ -1,0 +1,177 @@
+"""External reducers: reduction passes backed by a subprocess.
+
+An external reducer is a subprocess that shrink ray drives over the protocol in
+:mod:`shrinkray.reducers.protocol`. This module provides the shrink-ray side:
+
+- :func:`drive_external_reducer` runs the protocol over a pair of streams,
+  evaluating the reducer's queries with ``problem.is_interesting`` and feeding
+  the results back. It is independent of process management so it can be tested
+  directly.
+- :func:`external_reducer` wraps a command line as a :data:`ReductionPass`,
+  launching the subprocess, redirecting its stderr to a log file, and killing it
+  on completion, timeout, or cancellation.
+"""
+
+import os
+import subprocess
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import trio
+
+from shrinkray.passes.definitions import ReductionPass
+from shrinkray.problem import ReductionProblem
+from shrinkray.process import interrupt_wait_and_kill
+from shrinkray.reducers.protocol import (
+    LineReader,
+    decode_query,
+    encode_feedback,
+)
+
+
+# If the reducer emits no query for this long, we assume it has wedged and
+# terminate it. Overridable per reducer.
+DEFAULT_REDUCER_TIMEOUT = 60.0
+
+
+async def drive_external_reducer(
+    problem: ReductionProblem[bytes],
+    *,
+    send_stream: trio.abc.SendStream,
+    recv_stream: trio.abc.ReceiveStream,
+    timeout: float = DEFAULT_REDUCER_TIMEOUT,
+    parallelism: int = 1,
+) -> None:
+    """Run the shrink-ray side of the external reducer protocol.
+
+    Sends the initial test case, then reads candidate queries from
+    ``recv_stream`` and answers them on ``send_stream``, running interestingness
+    tests up to ``parallelism`` at a time. Returns when the reducer closes
+    ``recv_stream`` (EOF) or when no query arrives for ``timeout`` seconds.
+    """
+    reader = LineReader(recv_stream)
+    send_lock = trio.Lock()
+    # The current test case as last advertised to the reducer. Whenever the real
+    # current test case moves ahead of this, we push an unsolicited update.
+    last_advertised = problem.current_test_case
+
+    async def send_feedback(content: bytes, interesting: bool) -> None:
+        try:
+            await send_stream.send_all(encode_feedback(content, interesting))
+        except (trio.BrokenResourceError, trio.ClosedResourceError):
+            # The reducer exited while we were replying; nothing more to say.
+            pass
+
+    # Handshake: tell the reducer what it is starting from.
+    await send_feedback(problem.current_test_case, True)
+
+    # A semaphore (not a CapacityLimiter) because it is acquired by the reader
+    # task but released by the handler task, and semaphore tokens are not bound
+    # to the acquiring task.
+    slots = trio.Semaphore(max(parallelism, 1))
+
+    async def handle(candidate: bytes) -> None:
+        nonlocal last_advertised
+        try:
+            interesting = await problem.is_interesting(candidate)
+            async with send_lock:
+                await send_feedback(candidate, interesting)
+                current = problem.current_test_case
+                if current != last_advertised:
+                    last_advertised = current
+                    await send_feedback(current, True)
+        finally:
+            slots.release()
+
+    async with trio.open_nursery() as nursery:
+        while True:
+            # Acquire a slot before reading so that a flood of queries can't
+            # outrun our workers: once all slots are busy the pipe fills and the
+            # reducer blocks on its next send.
+            await slots.acquire()
+            line: bytes | None = None
+            with trio.move_on_after(timeout) as scope:
+                line = await reader.readline()
+            if scope.cancelled_caught:
+                slots.release()
+                break
+            if line is None:
+                slots.release()
+                break
+            if not line.strip():
+                slots.release()
+                continue
+            try:
+                candidate = decode_query(line)
+            except ValueError:
+                # Malformed line: ignore it rather than killing the reducer.
+                slots.release()
+                continue
+            nursery.start_soon(handle, candidate)
+        nursery.cancel_scope.cancel()
+
+
+async def _terminate(proc: trio.Process) -> None:
+    """Shut down the reducer subprocess, killing its process group if needed."""
+    with trio.CancelScope(shield=True):
+        await interrupt_wait_and_kill(proc)
+
+
+def external_reducer(
+    command: Sequence[str],
+    *,
+    log_file: str | os.PathLike[str] | None = None,
+    timeout: float = DEFAULT_REDUCER_TIMEOUT,
+    name: str | None = None,
+    extra_env: Mapping[str, str] | None = None,
+) -> ReductionPass[bytes]:
+    """Build a reduction pass that reduces via an external reducer subprocess.
+
+    Args:
+        command: The command (argv) to launch the reducer.
+        log_file: Path to append the reducer's stderr to. If None, stderr is
+            discarded.
+        timeout: Seconds without a query before the reducer is terminated.
+        name: Name for the pass (used in stats/status). Defaults to the command
+            basename.
+        extra_env: Extra environment variables for the subprocess.
+    """
+    command = list(command)
+    reducer_name = name or f"external:{os.path.basename(command[0])}"
+
+    async def run_external(problem: ReductionProblem[bytes]) -> None:
+        parallelism = problem.work.parallelism
+        env = dict(os.environ)
+        env["SHRINKRAY_REDUCER_PARALLELISM"] = str(parallelism)
+        if extra_env is not None:
+            env.update(extra_env)
+
+        if log_file is not None:
+            stderr_ctx: Any = open(log_file, "ab")
+        else:
+            stderr_ctx = open(os.devnull, "ab")
+
+        with stderr_ctx as stderr:
+            proc = await trio.lowlevel.open_process(
+                command,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=stderr.fileno(),
+                env=env,
+                preexec_fn=os.setsid,
+            )
+            try:
+                assert proc.stdin is not None
+                assert proc.stdout is not None
+                await drive_external_reducer(
+                    problem,
+                    send_stream=proc.stdin,
+                    recv_stream=proc.stdout,
+                    timeout=timeout,
+                    parallelism=parallelism,
+                )
+            finally:
+                await _terminate(proc)
+
+    run_external.__name__ = reducer_name
+    return run_external

--- a/src/shrinkray/passes/genericlanguages.py
+++ b/src/shrinkray/passes/genericlanguages.py
@@ -211,6 +211,19 @@ async def replace_falsey_with_zero(problem: ReductionProblem[bytes]) -> None:
     await problem.is_interesting(b"0")
 
 
+@regex_pass(rb"\b[A-Za-z_][A-Za-z0-9_]*\b")
+async def replace_identifiers_with_zero(problem: ReductionProblem[bytes]) -> None:
+    """Replace an identifier with the literal 0.
+
+    Turning a name reference into a constant often drops a dependency - e.g.
+    ``assert x`` becomes ``assert 0`` - which can unblock further reduction such
+    as deleting the definition the name referred to. Replacements that break the
+    test are rejected, so this can be tried indiscriminately on every identifier
+    (keywords included).
+    """
+    await problem.is_interesting(b"0")
+
+
 async def simplify_brackets(problem: ReductionProblem[bytes]) -> None:
     """Try to replace bracket types with simpler ones.
 

--- a/src/shrinkray/passes/python.py
+++ b/src/shrinkray/passes/python.py
@@ -1,3 +1,4 @@
+import sys
 from collections.abc import Callable
 from typing import Any, cast
 
@@ -34,6 +35,15 @@ def _exceeds_bracket_depth[AnyStr: (str, bytes)](source: AnyStr, limit: int) -> 
         elif code in _CLOSING_BRACKETS and depth > 0:
             depth -= 1
     return False
+
+
+def python_reducer_command() -> list[str]:
+    """The command that launches the built-in Python reducer subprocess.
+
+    Runs the reducer with the same interpreter shrink ray is using so it shares
+    this environment's libcst and shrinkray installation.
+    """
+    return [sys.executable, "-m", "shrinkray.reducers.python"]
 
 
 def is_python[AnyStr: (str, bytes)](source: AnyStr) -> bool:

--- a/src/shrinkray/reducer.py
+++ b/src/shrinkray/reducer.py
@@ -37,7 +37,7 @@ from shrinkray.passes.definitions import (
     ReductionPump,
     compose,
 )
-from shrinkray.passes.external import external_reducer
+from shrinkray.passes.external import ExternalReducerPass, external_reducer
 from shrinkray.passes.genericlanguages import (
     combine_expressions,
     cut_comment_like_things,
@@ -161,6 +161,12 @@ class ShrinkRay(Reducer[bytes]):
 
     # Directory to write external reducer stderr logs to, or None to discard.
     reducer_log_dir: str | None = None
+
+    # The external reducer passes built for this reducer, kept so their
+    # subprocesses can be torn down when the run finishes.
+    _external_reducer_passes: list[ExternalReducerPass] = attrs.field(
+        factory=list, init=False
+    )
 
     current_pump: ReductionPump[bytes] | None = None
 
@@ -298,13 +304,13 @@ class ShrinkRay(Reducer[bytes]):
         os.makedirs(self.reducer_log_dir, exist_ok=True)
         return os.path.join(self.reducer_log_dir, f"reducer-{name}.log")
 
-    def build_external_reducer_passes(self) -> list[ReductionPass[bytes]]:
+    def build_external_reducer_passes(self) -> list[ExternalReducerPass]:
         """Build the external reducer passes for the current test case.
 
         This includes the built-in Python reducer (when enabled and the test
         case looks like Python) followed by any user-specified reducers.
         """
-        passes: list[ReductionPass[bytes]] = []
+        passes: list[ExternalReducerPass] = []
         if self.python_reducer and is_python(self.target.current_test_case):
             passes.append(
                 external_reducer(
@@ -324,8 +330,15 @@ class ShrinkRay(Reducer[bytes]):
             )
         return passes
 
+    async def close_external_reducers(self) -> None:
+        """Tear down any external reducer subprocesses started during the run."""
+        with trio.CancelScope(shield=True):
+            for reducer_pass in self._external_reducer_passes:
+                await reducer_pass.aclose()
+
     def __attrs_post_init__(self) -> None:
         external_passes = self.build_external_reducer_passes()
+        self._external_reducer_passes = external_passes
         self.great_passes.extend(external_passes)
         self.initial_cuts.extend(external_passes)
         if self.enable_cpp_passes:
@@ -576,6 +589,12 @@ class ShrinkRay(Reducer[bytes]):
                 return
 
     async def run(self) -> None:
+        try:
+            await self._run()
+        finally:
+            await self.close_external_reducers()
+
+    async def _run(self) -> None:
         await self.target.setup()
 
         if await self.target.is_interesting(b""):

--- a/src/shrinkray/reducer.py
+++ b/src/shrinkray/reducer.py
@@ -1,3 +1,4 @@
+import os
 from abc import ABC, abstractmethod
 from collections.abc import Generator, Iterable
 from contextlib import contextmanager
@@ -7,6 +8,7 @@ import attrs
 import trio
 from attrs import define
 
+from shrinkray.history import sanitize_for_filename
 from shrinkray.passes.bytes import (
     Split,
     Tokenize,
@@ -35,6 +37,7 @@ from shrinkray.passes.definitions import (
     ReductionPump,
     compose,
 )
+from shrinkray.passes.external import external_reducer
 from shrinkray.passes.genericlanguages import (
     combine_expressions,
     cut_comment_like_things,
@@ -46,7 +49,7 @@ from shrinkray.passes.genericlanguages import (
 )
 from shrinkray.passes.json import JSON, JSON_PASSES
 from shrinkray.passes.patching import PatchApplier, Patches
-from shrinkray.passes.python import PYTHON_PASSES, is_python
+from shrinkray.passes.python import is_python, python_reducer_command
 from shrinkray.passes.sat import SAT_PASSES, DimacsCNF
 from shrinkray.passes.sequences import block_deletion, delete_duplicates
 from shrinkray.passes.treesitter import language_for_filename, treesitter_passes
@@ -147,6 +150,17 @@ class ShrinkRay(Reducer[bytes]):
     # Enables grammar-aware passes for the named tree-sitter language.
     # Set from the test case's file extension.
     treesitter_language: str | None = None
+
+    # Commands (argv lists) for user-specified external reducers, run as
+    # reduction passes. See shrinkray.passes.external.
+    external_reducers: list[list[str]] = attrs.Factory(list)
+
+    # Whether to run the built-in libcst Python reducer (as an external
+    # reducer) when the test case looks like Python.
+    python_reducer: bool = True
+
+    # Directory to write external reducer stderr logs to, or None to discard.
+    reducer_log_dir: str | None = None
 
     current_pump: ReductionPump[bytes] | None = None
 
@@ -277,10 +291,43 @@ class ShrinkRay(Reducer[bytes]):
     # such runs are skipped entirely.
     pass_fingerprints: dict[str, bytes] = attrs.Factory(dict)
 
+    def _log_file_for(self, name: str) -> str | None:
+        """Path for an external reducer's stderr log, or None to discard."""
+        if self.reducer_log_dir is None:
+            return None
+        os.makedirs(self.reducer_log_dir, exist_ok=True)
+        return os.path.join(self.reducer_log_dir, f"reducer-{name}.log")
+
+    def build_external_reducer_passes(self) -> list[ReductionPass[bytes]]:
+        """Build the external reducer passes for the current test case.
+
+        This includes the built-in Python reducer (when enabled and the test
+        case looks like Python) followed by any user-specified reducers.
+        """
+        passes: list[ReductionPass[bytes]] = []
+        if self.python_reducer and is_python(self.target.current_test_case):
+            passes.append(
+                external_reducer(
+                    python_reducer_command(),
+                    name="python",
+                    log_file=self._log_file_for("python"),
+                )
+            )
+        for i, command in enumerate(self.external_reducers):
+            name = f"reduce-with-{i}"
+            passes.append(
+                external_reducer(
+                    command,
+                    name=name,
+                    log_file=self._log_file_for(name),
+                )
+            )
+        return passes
+
     def __attrs_post_init__(self) -> None:
-        if is_python(self.target.current_test_case):
-            self.great_passes.extend(PYTHON_PASSES)
-            self.initial_cuts.extend(PYTHON_PASSES)
+        external_passes = self.build_external_reducer_passes()
+        self.great_passes.extend(external_passes)
+        self.initial_cuts.extend(external_passes)
         if self.enable_cpp_passes:
             self.great_passes.extend(CPP_PASSES)
             self.initial_cuts.extend(CPP_PASSES)
@@ -641,6 +688,11 @@ class KeyProblem(ReductionProblem[bytes]):
 
 @define
 class DirectoryShrinkRay(Reducer[dict[str, bytes]]):
+    # Forwarded to each per-file ShrinkRay. See ShrinkRay for details.
+    external_reducers: list[list[str]] = attrs.Factory(list)
+    python_reducer: bool = True
+    reducer_log_dir: str | None = None
+
     async def run(self):
         while True:
             prev = self.target.current_test_case
@@ -668,9 +720,18 @@ class DirectoryShrinkRay(Reducer[dict[str, bytes]]):
                     applier=applier,
                     key=k,
                 )
+                if self.reducer_log_dir is not None:
+                    key_log_dir: str | None = os.path.join(
+                        self.reducer_log_dir, sanitize_for_filename(k)
+                    )
+                else:
+                    key_log_dir = None
                 key_shrinkray = ShrinkRay(
                     enable_cpp_passes=any(k.endswith(s) for s in C_FILE_EXTENSIONS),
                     treesitter_language=language_for_filename(k),
                     target=key_problem,
+                    external_reducers=self.external_reducers,
+                    python_reducer=self.python_reducer,
+                    reducer_log_dir=key_log_dir,
                 )
                 nursery.start_soon(key_shrinkray.run)

--- a/src/shrinkray/reducer.py
+++ b/src/shrinkray/reducer.py
@@ -45,6 +45,7 @@ from shrinkray.passes.genericlanguages import (
     normalize_identifiers,
     reduce_integer_literals,
     replace_falsey_with_zero,
+    replace_identifiers_with_zero,
     simplify_brackets,
 )
 from shrinkray.passes.json import JSON, JSON_PASSES
@@ -237,6 +238,7 @@ class ShrinkRay(Reducer[bytes]):
             remove_whitespace,
             reduce_integer_literals,
             replace_falsey_with_zero,
+            replace_identifiers_with_zero,
             combine_expressions,
             merge_adjacent_strings,
             lexeme_based_deletions,

--- a/src/shrinkray/reducers/__init__.py
+++ b/src/shrinkray/reducers/__init__.py
@@ -1,0 +1,18 @@
+"""External reducer support for shrink ray.
+
+An *external reducer* is a subprocess that reduces a test case by talking to
+shrink ray over its stdin/stdout using a small newline-delimited JSON protocol
+(see :mod:`shrinkray.reducers.protocol`). Its stderr is redirected to a log
+file.
+
+This package contains:
+
+- ``protocol``: the wire protocol (message encoding/decoding + a line reader).
+- ``driver``: a :class:`~shrinkray.problem.ReductionProblem` implementation that
+  speaks the protocol, plus a helper for writing external reducers in Python.
+- ``python``: the built-in libcst-based Python reducer, implemented as an
+  external reducer.
+
+The shrink-ray side of the protocol lives in
+:mod:`shrinkray.passes.external`.
+"""

--- a/src/shrinkray/reducers/driver.py
+++ b/src/shrinkray/reducers/driver.py
@@ -25,12 +25,10 @@ from shrinkray.problem import (
     sort_key_for_initial,
 )
 from shrinkray.reducers.protocol import (
-    Feedback,
     LineReader,
-    ReduceRequest,
+    decode_feedback,
     encode_idle,
     encode_query,
-    parse_to_reducer,
 )
 from shrinkray.work import WorkContext
 
@@ -93,26 +91,29 @@ class RemoteReductionProblem(ReductionProblem[bytes]):
             self._stats.current_test_case_size = len(content)
             self._stats.reductions += 1
 
-    def handle_feedback(self, content: bytes, interesting: bool) -> None:
-        """Process one feedback message from shrink ray.
+    def handle_feedback(self, content: bytes, interesting: bool) -> bool:
+        """Try to resolve an outstanding query with a feedback message.
 
-        Updates the current test case and resolves a matching outstanding query
-        (if any). Feedback with no matching query is an unsolicited update to
-        the current test case.
+        Returns True if ``content`` matched an outstanding query (a reply),
+        resolving it and adopting the candidate as current if it is an
+        improvement. Returns False if it matched no query, in which case the
+        caller treats the feedback as a fresh current test case.
         """
-        self._consider(content, interesting)
         queue = self._waiters.get(content)
-        if queue:
-            event, slot = queue.popleft()
-            slot.append(interesting)
-            event.set()
-            if not queue:
-                del self._waiters[content]
+        if not queue:
+            return False
+        self._consider(content, interesting)
+        event, slot = queue.popleft()
+        slot.append(interesting)
+        event.set()
+        if not queue:
+            del self._waiters[content]
+        return True
 
     def set_current(self, content: bytes) -> None:
-        """Authoritatively set the current test case for a new reduce request.
+        """Authoritatively set the current test case shrink ray handed us.
 
-        Unlike adoption via feedback, this accepts ``content`` even when it is
+        Unlike adoption via a reply, this accepts ``content`` even when it is
         larger than what we hold: shrink ray is telling us what to reduce next
         (which may be bigger, e.g. after a pump).
         """
@@ -193,30 +194,29 @@ async def run_reducer(
 ) -> None:
     """Drive ``passes`` as an external reducer over the given streams.
 
-    The reducer stays alive across reduce requests: for each request it runs the
-    passes to a fixed point and reports idle, then waits for the next request. It
-    returns when shrink ray closes ``stdin_stream``.
+    The reducer stays alive across test cases: for each one shrink ray hands it
+    (as a feedback message that matches no outstanding query) it runs the passes
+    to a fixed point and reports idle, then waits for the next. It returns when
+    shrink ray closes ``stdin_stream``.
     """
     passes = list(passes)
     reader = LineReader(stdin_stream)
 
-    # The first message is a reduce request carrying the initial test case.
+    # The first message carries the initial test case.
     first = await reader.readline()
     if first is None:
         return
     try:
-        message = parse_to_reducer(first)
+        initial, _ = decode_feedback(first)
     except ValueError:
-        return
-    if not isinstance(message, ReduceRequest):
         return
 
     work = WorkContext(parallelism=parallelism, random=Random(seed))
     problem = RemoteReductionProblem(
-        message.content,
+        initial,
         send_stream=stdout_stream,
         work=work,
-        sort_key=sort_key_for_initial(message.content),
+        sort_key=sort_key_for_initial(initial),
     )
 
     reduce_send, reduce_recv = trio.open_memory_channel[None](float("inf"))
@@ -232,20 +232,19 @@ async def run_reducer(
                 if not line.strip():
                     continue
                 try:
-                    msg = parse_to_reducer(line)
+                    content, interesting = decode_feedback(line)
                 except ValueError:
                     continue
-                if isinstance(msg, Feedback):
-                    problem.handle_feedback(msg.content, msg.interesting)
-                else:  # ReduceRequest
-                    problem.set_current(msg.content)
+                # A reply resolves a query; anything else is a new test case.
+                if not problem.handle_feedback(content, interesting):
+                    problem.set_current(content)
                     await reduce_send.send(None)
             # Shrink ray is gone: unblock any pending queries and stop.
             problem.close()
             reduce_send.close()
             nursery.cancel_scope.cancel()
 
-        # Handle the initial reduce request, then wait for further ones.
+        # Reduce the initial test case, then any further ones.
         await run_passes_to_fixpoint(problem, passes)
         await problem.send_idle()
         while True:

--- a/src/shrinkray/reducers/driver.py
+++ b/src/shrinkray/reducers/driver.py
@@ -25,9 +25,12 @@ from shrinkray.problem import (
     sort_key_for_initial,
 )
 from shrinkray.reducers.protocol import (
+    Feedback,
     LineReader,
-    decode_feedback,
+    ReduceRequest,
+    encode_idle,
     encode_query,
+    parse_to_reducer,
 )
 from shrinkray.work import WorkContext
 
@@ -106,6 +109,24 @@ class RemoteReductionProblem(ReductionProblem[bytes]):
             if not queue:
                 del self._waiters[content]
 
+    def set_current(self, content: bytes) -> None:
+        """Authoritatively set the current test case for a new reduce request.
+
+        Unlike adoption via feedback, this accepts ``content`` even when it is
+        larger than what we hold: shrink ray is telling us what to reduce next
+        (which may be bigger, e.g. after a pump).
+        """
+        self.__current = content
+        self._stats.current_test_case_size = len(content)
+
+    async def send_idle(self) -> None:
+        """Tell shrink ray we have reached a fixpoint for the current request."""
+        async with self._send_lock:
+            try:
+                await self._send_stream.send_all(encode_idle())
+            except (trio.BrokenResourceError, trio.ClosedResourceError):
+                pass
+
     def close(self) -> None:
         """Mark the connection closed and fail all outstanding queries.
 
@@ -172,41 +193,66 @@ async def run_reducer(
 ) -> None:
     """Drive ``passes`` as an external reducer over the given streams.
 
-    Reads the handshake (the initial test case) from ``stdin_stream``, then runs
-    the passes to a fixed point while a background task reads feedback. Returns
-    when the passes finish or shrink ray closes ``stdin_stream``.
+    The reducer stays alive across reduce requests: for each request it runs the
+    passes to a fixed point and reports idle, then waits for the next request. It
+    returns when shrink ray closes ``stdin_stream``.
     """
     passes = list(passes)
     reader = LineReader(stdin_stream)
 
-    handshake = await reader.readline()
-    if handshake is None:
-        # Shrink ray closed the connection before sending anything.
+    # The first message is a reduce request carrying the initial test case.
+    first = await reader.readline()
+    if first is None:
         return
-    initial, _ = decode_feedback(handshake)
+    try:
+        message = parse_to_reducer(first)
+    except ValueError:
+        return
+    if not isinstance(message, ReduceRequest):
+        return
 
     work = WorkContext(parallelism=parallelism, random=Random(seed))
     problem = RemoteReductionProblem(
-        initial,
+        message.content,
         send_stream=stdout_stream,
         work=work,
-        sort_key=sort_key_for_initial(initial),
+        sort_key=sort_key_for_initial(message.content),
     )
+
+    reduce_send, reduce_recv = trio.open_memory_channel[None](float("inf"))
 
     async with trio.open_nursery() as nursery:
 
         @nursery.start_soon
-        async def read_feedback() -> None:
+        async def read_messages() -> None:
             while True:
                 line = await reader.readline()
                 if line is None:
                     break
-                if line.strip():
-                    content, interesting = decode_feedback(line)
-                    problem.handle_feedback(content, interesting)
+                if not line.strip():
+                    continue
+                try:
+                    msg = parse_to_reducer(line)
+                except ValueError:
+                    continue
+                if isinstance(msg, Feedback):
+                    problem.handle_feedback(msg.content, msg.interesting)
+                else:  # ReduceRequest
+                    problem.set_current(msg.content)
+                    await reduce_send.send(None)
             # Shrink ray is gone: unblock any pending queries and stop.
             problem.close()
+            reduce_send.close()
             nursery.cancel_scope.cancel()
 
+        # Handle the initial reduce request, then wait for further ones.
         await run_passes_to_fixpoint(problem, passes)
+        await problem.send_idle()
+        while True:
+            try:
+                await reduce_recv.receive()
+            except trio.EndOfChannel:
+                break
+            await run_passes_to_fixpoint(problem, passes)
+            await problem.send_idle()
         nursery.cancel_scope.cancel()

--- a/src/shrinkray/reducers/driver.py
+++ b/src/shrinkray/reducers/driver.py
@@ -1,0 +1,212 @@
+"""Helpers for writing external reducers in Python.
+
+This module provides :class:`RemoteReductionProblem`, a
+:class:`~shrinkray.problem.ReductionProblem` whose ``is_interesting`` is
+answered by shrink ray over the external-reducer protocol, and
+:func:`run_reducer`, which wires a list of ordinary reduction passes up to that
+problem and drives them to a fixed point.
+
+The upshot is that a pass written against ``ReductionProblem`` (such as the
+libcst-based Python passes) can run unchanged inside an external reducer
+subprocess: only the problem it runs against changes.
+"""
+
+from collections import deque
+from collections.abc import Callable, Iterable
+from random import Random
+from typing import Any
+
+import trio
+
+from shrinkray.passes.definitions import ReductionPass
+from shrinkray.problem import (
+    ReductionProblem,
+    ReductionStats,
+    sort_key_for_initial,
+)
+from shrinkray.reducers.protocol import (
+    LineReader,
+    decode_feedback,
+    encode_query,
+)
+from shrinkray.work import WorkContext
+
+
+class RemoteReductionProblem(ReductionProblem[bytes]):
+    """A reduction problem whose interestingness test lives in another process.
+
+    Candidates are sent to shrink ray as query messages; results arrive as
+    feedback messages, which :meth:`handle_feedback` dispatches back to the
+    awaiting :meth:`is_interesting` call. The current test case is kept in sync
+    by adopting any feedback content that is interesting and smaller than what
+    we currently hold.
+    """
+
+    def __init__(
+        self,
+        initial: bytes,
+        *,
+        send_stream: trio.abc.SendStream,
+        work: WorkContext,
+        sort_key: Callable[[bytes], Any],
+    ) -> None:
+        super().__init__(work=work)
+        self.__current = initial
+        self.__sort_key = sort_key
+        self._send_stream = send_stream
+        self._send_lock = trio.Lock()
+        # Outstanding queries, keyed by content. Each value is a queue of
+        # (event, result-slot) pairs so that duplicate concurrent queries for
+        # the same content are each resolved exactly once, in order.
+        self._waiters: dict[bytes, deque[tuple[trio.Event, list[bool]]]] = {}
+        self._cache: dict[bytes, bool] = {}
+        self._closed = False
+        self._stats = ReductionStats(
+            initial_test_case_size=len(initial),
+            current_test_case_size=len(initial),
+        )
+
+    @property
+    def current_test_case(self) -> bytes:
+        return self.__current
+
+    @property
+    def stats(self) -> ReductionStats:
+        return self._stats
+
+    def sort_key(self, test_case: bytes) -> Any:
+        return self.__sort_key(test_case)
+
+    def size(self, test_case: bytes) -> int:
+        return len(test_case)
+
+    def display(self, value: bytes) -> str:
+        return repr(value)
+
+    def _consider(self, content: bytes, interesting: bool) -> None:
+        """Adopt ``content`` as the current test case if it improves on it."""
+        if interesting and self.__sort_key(content) < self.__sort_key(self.__current):
+            self.__current = content
+            self._stats.current_test_case_size = len(content)
+            self._stats.reductions += 1
+
+    def handle_feedback(self, content: bytes, interesting: bool) -> None:
+        """Process one feedback message from shrink ray.
+
+        Updates the current test case and resolves a matching outstanding query
+        (if any). Feedback with no matching query is an unsolicited update to
+        the current test case.
+        """
+        self._consider(content, interesting)
+        queue = self._waiters.get(content)
+        if queue:
+            event, slot = queue.popleft()
+            slot.append(interesting)
+            event.set()
+            if not queue:
+                del self._waiters[content]
+
+    def close(self) -> None:
+        """Mark the connection closed and fail all outstanding queries.
+
+        Called when shrink ray closes the feedback stream. Any ``is_interesting``
+        call still awaiting a result is resolved as not interesting so it can
+        unwind rather than hang forever.
+        """
+        self._closed = True
+        for queue in self._waiters.values():
+            # Every queued waiter is unresolved (handle_feedback removes a waiter
+            # the moment it resolves it), so each still has an empty result slot.
+            for event, slot in queue:
+                slot.append(False)
+                event.set()
+        self._waiters.clear()
+
+    async def is_interesting(self, test_case: bytes) -> bool:
+        await trio.lowlevel.checkpoint()
+        if test_case == self.__current:
+            return True
+        try:
+            return self._cache[test_case]
+        except KeyError:
+            pass
+        if self._closed:
+            return False
+
+        event = trio.Event()
+        slot: list[bool] = []
+        self._waiters.setdefault(test_case, deque()).append((event, slot))
+        async with self._send_lock:
+            await self._send_stream.send_all(encode_query(test_case))
+
+        self._stats.calls += 1
+        await event.wait()
+        result = slot[0]
+        self._cache[test_case] = result
+        if result:
+            self._stats.interesting_calls += 1
+        return result
+
+
+async def run_passes_to_fixpoint(
+    problem: ReductionProblem[bytes],
+    passes: Iterable[ReductionPass[bytes]],
+) -> None:
+    """Run each pass in turn, repeating until a full round makes no progress."""
+    passes = list(passes)
+    while True:
+        prev = problem.current_test_case
+        for reduction_pass in passes:
+            await reduction_pass(problem)
+        if problem.current_test_case == prev:
+            return
+
+
+async def run_reducer(
+    passes: Iterable[ReductionPass[bytes]],
+    *,
+    stdin_stream: trio.abc.ReceiveStream,
+    stdout_stream: trio.abc.SendStream,
+    parallelism: int = 1,
+    seed: int = 0,
+) -> None:
+    """Drive ``passes`` as an external reducer over the given streams.
+
+    Reads the handshake (the initial test case) from ``stdin_stream``, then runs
+    the passes to a fixed point while a background task reads feedback. Returns
+    when the passes finish or shrink ray closes ``stdin_stream``.
+    """
+    passes = list(passes)
+    reader = LineReader(stdin_stream)
+
+    handshake = await reader.readline()
+    if handshake is None:
+        # Shrink ray closed the connection before sending anything.
+        return
+    initial, _ = decode_feedback(handshake)
+
+    work = WorkContext(parallelism=parallelism, random=Random(seed))
+    problem = RemoteReductionProblem(
+        initial,
+        send_stream=stdout_stream,
+        work=work,
+        sort_key=sort_key_for_initial(initial),
+    )
+
+    async with trio.open_nursery() as nursery:
+
+        @nursery.start_soon
+        async def read_feedback() -> None:
+            while True:
+                line = await reader.readline()
+                if line is None:
+                    break
+                if line.strip():
+                    content, interesting = decode_feedback(line)
+                    problem.handle_feedback(content, interesting)
+            # Shrink ray is gone: unblock any pending queries and stop.
+            problem.close()
+            nursery.cancel_scope.cancel()
+
+        await run_passes_to_fixpoint(problem, passes)
+        nursery.cancel_scope.cancel()

--- a/src/shrinkray/reducers/protocol.py
+++ b/src/shrinkray/reducers/protocol.py
@@ -4,27 +4,31 @@ An external reducer is a subprocess that communicates with shrink ray over
 stdin/stdout using newline-delimited JSON messages. Test-case content is
 base64-encoded so that arbitrary bytes survive the (textual) JSON transport.
 
-There are two message types:
+Messages shrink ray sends to the reducer:
 
-- **query** (reducer -> shrink ray): ``{"content": <base64>}``
+- **reduce** ``{"reduce": <base64>}`` — "reduce this test case to a fixpoint and
+  tell me when you are idle". The base64 payload is the current test case. The
+  first message the reducer receives is always a reduce request; further ones
+  arrive whenever shrink ray wants the reducer to work again (for example after
+  another pass has reduced the test case).
+- **feedback** ``{"content": <base64>, "interesting": <bool>}`` — the result of
+  the interestingness test for a query the reducer emitted, or an unsolicited
+  update to the current test case (for example after reformatting).
 
-  The reducer emits a candidate test case it wants evaluated.
+Messages the reducer sends to shrink ray:
 
-- **feedback** (shrink ray -> reducer): ``{"content": <base64>, "interesting": <bool>}``
+- **query** ``{"content": <base64>}`` — a candidate it wants evaluated.
+- **idle** ``{"idle": true}`` — "I have reached a fixpoint for the current
+  reduce request; I will do nothing until the next reduce request".
 
-  Shrink ray replies to each query with the result of its interestingness
-  test. The reducer is also sent one feedback message on launch (the initial
-  test case, with ``interesting`` true), and may be sent further unsolicited
-  feedback messages when the current test case changes underneath it (for
-  example because another pass reduced it, or because it was reformatted).
-
-The reducer correlates a feedback message with a query by its ``content``:
-feedback whose content matches an outstanding query is that query's result;
-feedback whose content does not is an update to the current test case.
+The reducer stays alive between reduce requests so that expensive startup (such
+as importing libcst) happens once. A reducer that instead exits at a fixpoint
+(closing its stdout) is also supported: shrink ray relaunches it next time.
 """
 
 import base64
 import json
+from dataclasses import dataclass
 from typing import Protocol
 
 
@@ -67,6 +71,78 @@ def decode_feedback(line: bytes | str) -> tuple[bytes, bool]:
             "feedback message must be an object with 'content' and 'interesting'"
         )
     return base64.b64decode(obj["content"]), bool(obj["interesting"])
+
+
+def encode_reduce(content: bytes) -> bytes:
+    """Encode a reduce request (shrink ray -> reducer) as a protocol line."""
+    obj = {"reduce": base64.b64encode(content).decode("ascii")}
+    return (json.dumps(obj) + "\n").encode("utf-8")
+
+
+def encode_idle() -> bytes:
+    """Encode an idle notification (reducer -> shrink ray) as a protocol line."""
+    return (json.dumps({"idle": True}) + "\n").encode("utf-8")
+
+
+# === Message classification ===
+#
+# Each direction carries two message kinds, so the reader classifies a line into
+# a small tagged object rather than assuming which kind it is.
+
+
+@dataclass(frozen=True)
+class ReduceRequest:
+    """Shrink ray asks the reducer to reduce ``content`` to a fixpoint."""
+
+    content: bytes
+
+
+@dataclass(frozen=True)
+class Feedback:
+    """Shrink ray reports the interestingness of ``content``."""
+
+    content: bytes
+    interesting: bool
+
+
+@dataclass(frozen=True)
+class Query:
+    """The reducer asks whether ``content`` is interesting."""
+
+    content: bytes
+
+
+@dataclass(frozen=True)
+class Idle:
+    """The reducer reports it has reached a fixpoint."""
+
+
+def parse_to_reducer(line: bytes | str) -> ReduceRequest | Feedback:
+    """Classify a message shrink ray sends to the reducer.
+
+    Raises ValueError if the line is not a recognised message.
+    """
+    obj = json.loads(line)
+    if isinstance(obj, dict):
+        if "reduce" in obj:
+            return ReduceRequest(base64.b64decode(obj["reduce"]))
+        if "content" in obj and "interesting" in obj:
+            return Feedback(base64.b64decode(obj["content"]), bool(obj["interesting"]))
+    raise ValueError("unrecognised message to reducer")
+
+
+def parse_from_reducer(line: bytes | str) -> Query | Idle:
+    """Classify a message the reducer sends to shrink ray.
+
+    Raises ValueError if the line is not a recognised message.
+    """
+    obj = json.loads(line)
+    if isinstance(obj, dict):
+        if obj.get("idle") is True:
+            return Idle()
+        if "content" in obj:
+            return Query(base64.b64decode(obj["content"]))
+    raise ValueError("unrecognised message from reducer")
 
 
 class ReceiveStream(Protocol):

--- a/src/shrinkray/reducers/protocol.py
+++ b/src/shrinkray/reducers/protocol.py
@@ -72,9 +72,7 @@ def decode_feedback(line: bytes | str) -> tuple[bytes, bool]:
 class ReceiveStream(Protocol):
     """The subset of a trio receive stream that :class:`LineReader` needs."""
 
-    async def receive_some(
-        self, max_bytes: int | None = None
-    ) -> bytes | bytearray: ...
+    async def receive_some(self, max_bytes: int | None = None) -> bytes | bytearray: ...
 
 
 class LineReader:

--- a/src/shrinkray/reducers/protocol.py
+++ b/src/shrinkray/reducers/protocol.py
@@ -6,23 +6,23 @@ base64-encoded so that arbitrary bytes survive the (textual) JSON transport.
 
 Messages shrink ray sends to the reducer:
 
-- **reduce** ``{"reduce": <base64>}`` — "reduce this test case to a fixpoint and
-  tell me when you are idle". The base64 payload is the current test case. The
-  first message the reducer receives is always a reduce request; further ones
-  arrive whenever shrink ray wants the reducer to work again (for example after
-  another pass has reduced the test case).
-- **feedback** ``{"content": <base64>, "interesting": <bool>}`` — the result of
-  the interestingness test for a query the reducer emitted, or an unsolicited
-  update to the current test case (for example after reformatting).
+- **feedback** ``{"content": <base64>, "interesting": <bool>}`` — either the
+  result of the interestingness test for a query the reducer emitted, or, when
+  the content matches no outstanding query, the current test case for the
+  reducer to work on. The reducer correlates a reply with a query by its
+  ``content``; a feedback message it did not ask for (interesting, unmatched) is
+  a fresh current test case to reduce to a fixpoint and then report ``idle`` on.
+  The first message the reducer receives is one of these, carrying the initial
+  test case.
 
 Messages the reducer sends to shrink ray:
 
 - **query** ``{"content": <base64>}`` — a candidate it wants evaluated.
-- **idle** ``{"idle": true}`` — "I have reached a fixpoint for the current
-  reduce request; I will do nothing until the next reduce request".
+- **idle** ``{"idle": true}`` — "I have reached a fixpoint for the current test
+  case; I will do nothing until I am given a new one".
 
-The reducer stays alive between reduce requests so that expensive startup (such
-as importing libcst) happens once. A reducer that instead exits at a fixpoint
+The reducer stays alive between test cases so that expensive startup (such as
+importing libcst) happens once. A reducer that instead exits at a fixpoint
 (closing its stdout) is also supported: shrink ray relaunches it next time.
 """
 
@@ -73,36 +73,15 @@ def decode_feedback(line: bytes | str) -> tuple[bytes, bool]:
     return base64.b64decode(obj["content"]), bool(obj["interesting"])
 
 
-def encode_reduce(content: bytes) -> bytes:
-    """Encode a reduce request (shrink ray -> reducer) as a protocol line."""
-    obj = {"reduce": base64.b64encode(content).decode("ascii")}
-    return (json.dumps(obj) + "\n").encode("utf-8")
-
-
 def encode_idle() -> bytes:
     """Encode an idle notification (reducer -> shrink ray) as a protocol line."""
     return (json.dumps({"idle": True}) + "\n").encode("utf-8")
 
 
-# === Message classification ===
+# === Reducer -> shrink ray message classification ===
 #
-# Each direction carries two message kinds, so the reader classifies a line into
+# This direction carries two message kinds, so the reader classifies a line into
 # a small tagged object rather than assuming which kind it is.
-
-
-@dataclass(frozen=True)
-class ReduceRequest:
-    """Shrink ray asks the reducer to reduce ``content`` to a fixpoint."""
-
-    content: bytes
-
-
-@dataclass(frozen=True)
-class Feedback:
-    """Shrink ray reports the interestingness of ``content``."""
-
-    content: bytes
-    interesting: bool
 
 
 @dataclass(frozen=True)
@@ -115,20 +94,6 @@ class Query:
 @dataclass(frozen=True)
 class Idle:
     """The reducer reports it has reached a fixpoint."""
-
-
-def parse_to_reducer(line: bytes | str) -> ReduceRequest | Feedback:
-    """Classify a message shrink ray sends to the reducer.
-
-    Raises ValueError if the line is not a recognised message.
-    """
-    obj = json.loads(line)
-    if isinstance(obj, dict):
-        if "reduce" in obj:
-            return ReduceRequest(base64.b64decode(obj["reduce"]))
-        if "content" in obj and "interesting" in obj:
-            return Feedback(base64.b64decode(obj["content"]), bool(obj["interesting"]))
-    raise ValueError("unrecognised message to reducer")
 
 
 def parse_from_reducer(line: bytes | str) -> Query | Idle:

--- a/src/shrinkray/reducers/protocol.py
+++ b/src/shrinkray/reducers/protocol.py
@@ -1,0 +1,112 @@
+"""Wire protocol for external reducers.
+
+An external reducer is a subprocess that communicates with shrink ray over
+stdin/stdout using newline-delimited JSON messages. Test-case content is
+base64-encoded so that arbitrary bytes survive the (textual) JSON transport.
+
+There are two message types:
+
+- **query** (reducer -> shrink ray): ``{"content": <base64>}``
+
+  The reducer emits a candidate test case it wants evaluated.
+
+- **feedback** (shrink ray -> reducer): ``{"content": <base64>, "interesting": <bool>}``
+
+  Shrink ray replies to each query with the result of its interestingness
+  test. The reducer is also sent one feedback message on launch (the initial
+  test case, with ``interesting`` true), and may be sent further unsolicited
+  feedback messages when the current test case changes underneath it (for
+  example because another pass reduced it, or because it was reformatted).
+
+The reducer correlates a feedback message with a query by its ``content``:
+feedback whose content matches an outstanding query is that query's result;
+feedback whose content does not is an update to the current test case.
+"""
+
+import base64
+import json
+from typing import Protocol
+
+
+def encode_query(content: bytes) -> bytes:
+    """Encode a candidate query (reducer -> shrink ray) as a protocol line."""
+    obj = {"content": base64.b64encode(content).decode("ascii")}
+    return (json.dumps(obj) + "\n").encode("utf-8")
+
+
+def decode_query(line: bytes | str) -> bytes:
+    """Decode a query line into its content bytes.
+
+    Raises ValueError (or a subclass such as json.JSONDecodeError) if the line
+    is not a well-formed query.
+    """
+    obj = json.loads(line)
+    if not isinstance(obj, dict) or "content" not in obj:
+        raise ValueError("query message must be an object with a 'content' field")
+    return base64.b64decode(obj["content"])
+
+
+def encode_feedback(content: bytes, interesting: bool) -> bytes:
+    """Encode a feedback message (shrink ray -> reducer) as a protocol line."""
+    obj = {
+        "content": base64.b64encode(content).decode("ascii"),
+        "interesting": bool(interesting),
+    }
+    return (json.dumps(obj) + "\n").encode("utf-8")
+
+
+def decode_feedback(line: bytes | str) -> tuple[bytes, bool]:
+    """Decode a feedback line into ``(content, interesting)``.
+
+    Raises ValueError (or a subclass such as json.JSONDecodeError) if the line
+    is not a well-formed feedback message.
+    """
+    obj = json.loads(line)
+    if not isinstance(obj, dict) or "content" not in obj or "interesting" not in obj:
+        raise ValueError(
+            "feedback message must be an object with 'content' and 'interesting'"
+        )
+    return base64.b64decode(obj["content"]), bool(obj["interesting"])
+
+
+class ReceiveStream(Protocol):
+    """The subset of a trio receive stream that :class:`LineReader` needs."""
+
+    async def receive_some(
+        self, max_bytes: int | None = None
+    ) -> bytes | bytearray: ...
+
+
+class LineReader:
+    """Buffered newline-delimited reader over an async byte stream.
+
+    Wraps any object with an awaitable ``receive_some`` method (such as a trio
+    ``ReceiveStream``) and yields whole lines, buffering partial reads. A final
+    line without a trailing newline is returned before EOF.
+    """
+
+    def __init__(self, stream: ReceiveStream, max_chunk: int = 65536) -> None:
+        self._stream = stream
+        self._buffer = bytearray()
+        self._max_chunk = max_chunk
+        self._eof = False
+
+    async def readline(self) -> bytes | None:
+        """Return the next line (without its trailing newline), or None at EOF."""
+        while True:
+            newline = self._buffer.find(b"\n")
+            if newline >= 0:
+                line = bytes(self._buffer[:newline])
+                del self._buffer[: newline + 1]
+                return line
+            if self._eof:
+                if self._buffer:
+                    line = bytes(self._buffer)
+                    self._buffer.clear()
+                    return line
+                return None
+            chunk = await self._stream.receive_some(self._max_chunk)
+            if chunk:
+                self._buffer.extend(chunk)
+            else:
+                self._eof = True

--- a/src/shrinkray/reducers/python.py
+++ b/src/shrinkray/reducers/python.py
@@ -1,0 +1,46 @@
+"""The built-in libcst-based Python reducer, as an external reducer.
+
+This runs the ordinary :data:`~shrinkray.passes.python.PYTHON_PASSES` against a
+:class:`~shrinkray.reducers.driver.RemoteReductionProblem`, so shrink ray's
+Python-specific reductions execute in a subprocess that talks to shrink ray over
+the external-reducer protocol.
+
+It is launched by shrink ray as ``python -m shrinkray.reducers.python`` (see
+:func:`shrinkray.passes.python.python_reducer_command`). Parallelism and the
+random seed are taken from the environment.
+"""
+
+import os
+
+import trio
+
+from shrinkray.passes.python import PYTHON_PASSES
+from shrinkray.reducers.driver import run_reducer
+
+
+async def serve(parallelism: int, seed: int) -> None:
+    """Run the reducer over this process's stdin/stdout."""
+    stdin_stream = trio.lowlevel.FdStream(os.dup(0))
+    stdout_stream = trio.lowlevel.FdStream(os.dup(1))
+    try:
+        await run_reducer(
+            PYTHON_PASSES,
+            stdin_stream=stdin_stream,
+            stdout_stream=stdout_stream,
+            parallelism=parallelism,
+            seed=seed,
+        )
+    finally:
+        await stdin_stream.aclose()
+        await stdout_stream.aclose()
+
+
+def main() -> None:
+    """Entry point for the ``shrinkray.reducers.python`` module."""
+    parallelism = int(os.environ.get("SHRINKRAY_REDUCER_PARALLELISM", "1"))
+    seed = int(os.environ.get("SHRINKRAY_REDUCER_SEED", "0"))
+    trio.run(serve, parallelism, seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/shrinkray/state.py
+++ b/src/shrinkray/state.py
@@ -254,6 +254,11 @@ class ShrinkRayState[TestCase](ABC):
     # When a test returns this code, it's recorded but not used for reduction
     also_interesting_code: int | None = None
 
+    # External reducers (argv lists) to run as reduction passes, and whether to
+    # run the built-in Python reducer. Passed through to the reducer.
+    external_reducers: list[list[str]] = attrs.Factory(list)
+    python_reducer: bool = True
+
     # Set of test cases to exclude from interestingness (for restart-from-point)
     # These are byte-identical matches of previously reduced values
     excluded_test_cases: set[bytes] | None = None
@@ -370,6 +375,16 @@ class ShrinkRayState[TestCase](ABC):
             test_case_bytes = self._get_test_case_bytes(test_case)
             output = self._get_last_captured_output()
             self.history_manager.record_also_interesting(test_case_bytes, output)
+
+    def reducer_log_dir(self) -> str | None:
+        """Directory for external reducer stderr logs, or None to discard them.
+
+        Uses a subdirectory of the run's history directory when history is
+        enabled, so reducer logs live alongside the run's other artifacts.
+        """
+        if self.history_manager is not None:
+            return os.path.join(self.history_manager.history_dir, "reducers")
+        return None
 
     @abstractmethod
     def new_reducer(self, problem: ReductionProblem[TestCase]) -> Reducer[TestCase]: ...
@@ -978,6 +993,9 @@ class ShrinkRayStateSingleFile(ShrinkRayState[bytes]):
             problem,
             enable_cpp_passes=os.path.splitext(self.filename)[1] in C_FILE_EXTENSIONS,
             treesitter_language=language_for_filename(self.filename),
+            external_reducers=self.external_reducers,
+            python_reducer=self.python_reducer,
+            reducer_log_dir=self.reducer_log_dir(),
         )
 
     def _get_initial_bytes(self) -> bytes:
@@ -1099,7 +1117,12 @@ class ShrinkRayDirectoryState(ShrinkRayState[dict[str, bytes]]):
     def new_reducer(
         self, problem: ReductionProblem[dict[str, bytes]]
     ) -> Reducer[dict[str, bytes]]:
-        return DirectoryShrinkRay(target=problem)
+        return DirectoryShrinkRay(
+            target=problem,
+            external_reducers=self.external_reducers,
+            python_reducer=self.python_reducer,
+            reducer_log_dir=self.reducer_log_dir(),
+        )
 
     def _get_initial_bytes(self) -> bytes:
         # Serialize directory content for history recording

--- a/src/shrinkray/subprocess/client.py
+++ b/src/shrinkray/subprocess/client.py
@@ -151,6 +151,8 @@ class SubprocessClient:
         skip_validation: bool = False,
         history_enabled: bool = True,
         also_interesting_code: int | None = None,
+        external_reducers: list[list[str]] | None = None,
+        python_reducer: bool = True,
     ) -> Response:
         """Start the reduction process."""
         params: dict[str, Any] = {
@@ -165,6 +167,8 @@ class SubprocessClient:
             "skip_validation": skip_validation,
             "history_enabled": history_enabled,
             "also_interesting_code": also_interesting_code,
+            "external_reducers": external_reducers or [],
+            "python_reducer": python_reducer,
         }
         if parallelism is not None:
             params["parallelism"] = parallelism

--- a/src/shrinkray/subprocess/worker.py
+++ b/src/shrinkray/subprocess/worker.py
@@ -203,6 +203,8 @@ class ReducerWorker:
         skip_validation = params.get("skip_validation", False)
         history_enabled = params.get("history_enabled", True)
         also_interesting_code = params.get("also_interesting_code")
+        external_reducers = params.get("external_reducers", [])
+        python_reducer = params.get("python_reducer", True)
 
         state_kwargs: dict[str, Any] = {
             "input_type": input_type,
@@ -219,6 +221,8 @@ class ReducerWorker:
             "volume": volume,
             "history_enabled": history_enabled,
             "also_interesting_code": also_interesting_code,
+            "external_reducers": external_reducers,
+            "python_reducer": python_reducer,
         }
 
         if os.path.isdir(filename):

--- a/src/shrinkray/tui.py
+++ b/src/shrinkray/tui.py
@@ -130,6 +130,8 @@ class ReductionClientProtocol(Protocol):
         skip_validation: bool = False,
         history_enabled: bool = True,
         also_interesting_code: int | None = None,
+        external_reducers: list[list[str]] | None = None,
+        python_reducer: bool = True,
     ) -> Response: ...
     async def cancel(self) -> Response: ...
     async def disable_pass(self, pass_name: str) -> Response: ...
@@ -1663,6 +1665,8 @@ class ShrinkRayApp(App[None]):
         theme: ThemeMode = "auto",
         history_enabled: bool = True,
         also_interesting_code: int | None = None,
+        external_reducers: list[list[str]] | None = None,
+        python_reducer: bool = True,
     ) -> None:
         super().__init__()
         self._file_path = file_path
@@ -1683,6 +1687,8 @@ class ShrinkRayApp(App[None]):
         self._theme = theme
         self._history_enabled = history_enabled
         self._also_interesting_code = also_interesting_code
+        self._external_reducers = external_reducers or []
+        self._python_reducer = python_reducer
         self._latest_pass_stats: list[PassStatsData] = []
         self._current_pass_name: str = ""
         self._disabled_passes: list[str] = []
@@ -1845,6 +1851,8 @@ class ShrinkRayApp(App[None]):
                     skip_validation=True,
                     history_enabled=self._history_enabled,
                     also_interesting_code=self._also_interesting_code,
+                    external_reducers=self._external_reducers,
+                    python_reducer=self._python_reducer,
                 )
 
                 if response.error:
@@ -2047,6 +2055,8 @@ def run_textual_ui(
     theme: ThemeMode = "auto",
     history_enabled: bool = True,
     also_interesting_code: int | None = None,
+    external_reducers: list[list[str]] | None = None,
+    python_reducer: bool = True,
 ) -> None:
     """Run the textual TUI.
 
@@ -2070,6 +2080,8 @@ def run_textual_ui(
         theme=theme,
         history_enabled=history_enabled,
         also_interesting_code=also_interesting_code,
+        external_reducers=external_reducers,
+        python_reducer=python_reducer,
     )
     app.run()
     if app.return_code:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,14 @@ from unittest.mock import patch
 import click
 import pytest
 
-from shrinkray.cli import EnumChoice, InputType, UIType, validate_command, validate_ui
+from shrinkray.cli import (
+    EnumChoice,
+    InputType,
+    UIType,
+    validate_command,
+    validate_commands,
+    validate_ui,
+)
 
 
 # === validate_command tests ===
@@ -60,6 +67,26 @@ def test_validate_command_raises_for_unparseable_command():
     # Regression test: an unclosed quote raised ValueError from shlex.
     with pytest.raises(click.BadParameter):
         validate_command(None, None, "'unclosed quote")
+
+
+# === validate_commands tests (repeatable --reduce-with) ===
+
+
+def test_validate_commands_empty_tuple():
+    assert validate_commands(None, None, ()) == []
+
+
+def test_validate_commands_resolves_each():
+    result = validate_commands(None, None, ("ls -la", "ls"))
+    assert len(result) == 2
+    assert os.path.basename(result[0][0]) == "ls"
+    assert result[0][1:] == ["-la"]
+    assert os.path.basename(result[1][0]) == "ls"
+
+
+def test_validate_commands_raises_for_nonexistent():
+    with pytest.raises(click.BadParameter, match="command not found"):
+        validate_commands(None, None, ("ls", "nonexistent_command_xyz123"))
 
 
 # === EnumChoice tests ===

--- a/tests/test_external_driver.py
+++ b/tests/test_external_driver.py
@@ -11,7 +11,6 @@ from shrinkray.reducers.protocol import (
     Query,
     decode_query,
     encode_feedback,
-    encode_reduce,
     parse_from_reducer,
 )
 from shrinkray.work import WorkContext
@@ -55,24 +54,21 @@ def test_properties() -> None:
     assert problem.sort_key(b"a") < problem.sort_key(b"ab")
 
 
-def test_handle_feedback_adopts_smaller_interesting() -> None:
+def test_handle_feedback_unmatched_returns_false() -> None:
     problem = make_problem(b"hello world\n")
-    problem.handle_feedback(b"hi\n", True)
-    assert problem.current_test_case == b"hi\n"
-    assert problem.stats.reductions == 1
-    assert problem.stats.current_test_case_size == 3
-
-
-def test_handle_feedback_ignores_larger() -> None:
-    problem = make_problem(b"hi\n")
-    problem.handle_feedback(b"a much longer thing\n", True)
-    assert problem.current_test_case == b"hi\n"
-
-
-def test_handle_feedback_ignores_uninteresting() -> None:
-    problem = make_problem(b"hello world\n")
-    problem.handle_feedback(b"hi\n", False)
+    # No outstanding query matches this content, so it is not a reply.
+    assert problem.handle_feedback(b"hi\n", True) is False
     assert problem.current_test_case == b"hello world\n"
+
+
+def test_set_current_sets_authoritatively() -> None:
+    problem = make_problem(b"hello world\n")
+    problem.set_current(b"hi\n")  # smaller
+    assert problem.current_test_case == b"hi\n"
+    # Even a larger value is adopted: shrink ray is telling us what to reduce.
+    problem.set_current(b"a much larger value\n")
+    assert problem.current_test_case == b"a much larger value\n"
+    assert problem.stats.current_test_case_size == len(b"a much larger value\n")
 
 
 # === is_interesting ===
@@ -98,10 +94,13 @@ async def test_is_interesting_awaits_feedback() -> None:
         await wait_all_tasks_blocked()
         # The query was sent, and the call is now blocked awaiting feedback.
         assert decode_query(bytes(problem._send_stream.sent)) == b"smaller\n"  # type: ignore[attr-defined]
-        problem.handle_feedback(b"smaller\n", True)
+        # The reply matches the outstanding query and adopts the candidate.
+        assert problem.handle_feedback(b"smaller\n", True) is True
 
     assert results == [True]
     assert problem.current_test_case == b"smaller\n"
+    assert problem.stats.reductions == 1
+    assert problem.stats.current_test_case_size == len(b"smaller\n")
 
 
 async def test_is_interesting_caches_results() -> None:
@@ -178,17 +177,27 @@ async def test_run_reducer_returns_on_empty_handshake() -> None:
     await query_recv.aclose()
 
 
-async def test_run_reducer_ignores_non_reduce_first_message() -> None:
-    """A first message that is not a reduce request ends the reducer."""
+async def test_run_reducer_reduces_first_message_then_exits() -> None:
+    """The first message is the initial test case; with nothing to reduce the
+    reducer reports idle and then exits when the stream closes."""
     feedback_send, feedback_recv = memory_stream_one_way_pair()
     query_send, query_recv = memory_stream_one_way_pair()
+    reader = LineReader(query_recv)
 
-    # Send feedback (not a reduce request) as the first message.
-    await feedback_send.send_all(encode_feedback(b"x = 1\n", True))
-    await feedback_send.aclose()
+    async with trio.open_nursery() as nursery:
 
-    await run_reducer([], stdin_stream=feedback_recv, stdout_stream=query_send)
-    await query_recv.aclose()
+        @nursery.start_soon
+        async def _reducer() -> None:
+            await run_reducer([], stdin_stream=feedback_recv, stdout_stream=query_send)
+            await query_send.aclose()
+
+        @nursery.start_soon
+        async def _shrinkray() -> None:
+            await feedback_send.send_all(encode_feedback(b"x = 1\n", True))
+            idle_line = await reader.readline()
+            assert idle_line is not None
+            assert isinstance(parse_from_reducer(idle_line), Idle)
+            await feedback_send.aclose()
 
 
 async def test_run_reducer_returns_on_malformed_first_message() -> None:
@@ -202,8 +211,8 @@ async def test_run_reducer_returns_on_malformed_first_message() -> None:
     await query_recv.aclose()
 
 
-async def test_run_reducer_handles_multiple_reduce_requests() -> None:
-    """The reducer stays alive and reduces again on each reduce request."""
+async def test_run_reducer_handles_multiple_test_cases() -> None:
+    """The reducer stays alive and reduces again on each new test case."""
     feedback_send, feedback_recv = memory_stream_one_way_pair()
     query_send, query_recv = memory_stream_one_way_pair()
     reader = LineReader(query_recv)
@@ -213,9 +222,9 @@ async def test_run_reducer_handles_multiple_reduce_requests() -> None:
         if len(current) > 1:
             await problem.is_interesting(current[:-1])
 
-    async def one_session(request_content: bytes) -> bytes:
-        """Send a reduce request, answer its single query (False), await idle."""
-        await feedback_send.send_all(encode_reduce(request_content))
+    async def one_session(test_case: bytes) -> bytes:
+        """Hand over a test case, answer its single query (False), await idle."""
+        await feedback_send.send_all(encode_feedback(test_case, True))
         query_line = await reader.readline()
         assert query_line is not None
         query = parse_from_reducer(query_line)
@@ -239,11 +248,11 @@ async def test_run_reducer_handles_multiple_reduce_requests() -> None:
 
         @nursery.start_soon
         async def _shrinkray() -> None:
-            # First reduce request.
+            # First test case (consumed as the initial).
             assert await one_session(b"abcd") == b"abc"
-            # A malformed message between requests is ignored.
+            # A malformed message between test cases is ignored.
             await feedback_send.send_all(b"junk\n")
-            # Second reduce request with a different (smaller) current.
+            # A second, different test case handed over while the reducer is idle.
             assert await one_session(b"xy") == b"x"
             await feedback_send.aclose()
 
@@ -292,7 +301,7 @@ async def test_run_reducer_skips_blank_lines() -> None:
         @nursery.start_soon
         async def _shrinkray() -> None:
             reader = LineReader(query_recv)
-            await feedback_send.send_all(encode_reduce(b"x = 1\n"))
+            await feedback_send.send_all(encode_feedback(b"x = 1\n", True))
             await feedback_send.send_all(b"\n")  # blank line: should be skipped
             query_line = await reader.readline()
             assert query_line is not None

--- a/tests/test_external_driver.py
+++ b/tests/test_external_driver.py
@@ -6,9 +6,13 @@ from trio.testing import memory_stream_one_way_pair, wait_all_tasks_blocked
 from shrinkray.problem import ReductionProblem, sort_key_for_initial
 from shrinkray.reducers.driver import RemoteReductionProblem, run_reducer
 from shrinkray.reducers.protocol import (
+    Idle,
     LineReader,
+    Query,
     decode_query,
     encode_feedback,
+    encode_reduce,
+    parse_from_reducer,
 )
 from shrinkray.work import WorkContext
 
@@ -174,8 +178,100 @@ async def test_run_reducer_returns_on_empty_handshake() -> None:
     await query_recv.aclose()
 
 
-async def test_run_reducer_skips_blank_feedback_lines() -> None:
-    """Blank feedback lines are ignored by the reducer's feedback reader."""
+async def test_run_reducer_ignores_non_reduce_first_message() -> None:
+    """A first message that is not a reduce request ends the reducer."""
+    feedback_send, feedback_recv = memory_stream_one_way_pair()
+    query_send, query_recv = memory_stream_one_way_pair()
+
+    # Send feedback (not a reduce request) as the first message.
+    await feedback_send.send_all(encode_feedback(b"x = 1\n", True))
+    await feedback_send.aclose()
+
+    await run_reducer([], stdin_stream=feedback_recv, stdout_stream=query_send)
+    await query_recv.aclose()
+
+
+async def test_run_reducer_returns_on_malformed_first_message() -> None:
+    """A malformed first message ends the reducer cleanly."""
+    feedback_send, feedback_recv = memory_stream_one_way_pair()
+    query_send, query_recv = memory_stream_one_way_pair()
+    await feedback_send.send_all(b"garbage not json\n")
+    await feedback_send.aclose()
+
+    await run_reducer([], stdin_stream=feedback_recv, stdout_stream=query_send)
+    await query_recv.aclose()
+
+
+async def test_run_reducer_handles_multiple_reduce_requests() -> None:
+    """The reducer stays alive and reduces again on each reduce request."""
+    feedback_send, feedback_recv = memory_stream_one_way_pair()
+    query_send, query_recv = memory_stream_one_way_pair()
+    reader = LineReader(query_recv)
+
+    async def chop_last_byte(problem: ReductionProblem[bytes]) -> None:
+        current = problem.current_test_case
+        if len(current) > 1:
+            await problem.is_interesting(current[:-1])
+
+    async def one_session(request_content: bytes) -> bytes:
+        """Send a reduce request, answer its single query (False), await idle."""
+        await feedback_send.send_all(encode_reduce(request_content))
+        query_line = await reader.readline()
+        assert query_line is not None
+        query = parse_from_reducer(query_line)
+        assert isinstance(query, Query)
+        await feedback_send.send_all(encode_feedback(query.content, False))
+        idle_line = await reader.readline()
+        assert idle_line is not None
+        assert isinstance(parse_from_reducer(idle_line), Idle)
+        return query.content
+
+    async with trio.open_nursery() as nursery:
+
+        @nursery.start_soon
+        async def _reducer() -> None:
+            await run_reducer(
+                [chop_last_byte],
+                stdin_stream=feedback_recv,
+                stdout_stream=query_send,
+            )
+            await query_send.aclose()
+
+        @nursery.start_soon
+        async def _shrinkray() -> None:
+            # First reduce request.
+            assert await one_session(b"abcd") == b"abc"
+            # A malformed message between requests is ignored.
+            await feedback_send.send_all(b"junk\n")
+            # Second reduce request with a different (smaller) current.
+            assert await one_session(b"xy") == b"x"
+            await feedback_send.aclose()
+
+
+async def test_send_idle_tolerates_broken_stream() -> None:
+    """send_idle swallows a broken send stream rather than raising."""
+
+    class BrokenStream(trio.abc.SendStream):
+        async def send_all(self, data: bytes | bytearray | memoryview) -> None:
+            raise trio.BrokenResourceError
+
+        async def wait_send_all_might_not_block(self) -> None:
+            await trio.lowlevel.checkpoint()
+
+        async def aclose(self) -> None:
+            await trio.lowlevel.checkpoint()
+
+    problem = RemoteReductionProblem(
+        b"x",
+        send_stream=BrokenStream(),
+        work=WorkContext(parallelism=1),
+        sort_key=sort_key_for_initial(b"x"),
+    )
+    await problem.send_idle()  # must not raise
+
+
+async def test_run_reducer_skips_blank_lines() -> None:
+    """Blank lines are ignored by the reducer's message reader."""
     feedback_send, feedback_recv = memory_stream_one_way_pair()
     query_send, query_recv = memory_stream_one_way_pair()
 
@@ -195,11 +291,15 @@ async def test_run_reducer_skips_blank_feedback_lines() -> None:
 
         @nursery.start_soon
         async def _shrinkray() -> None:
-            await feedback_send.send_all(encode_feedback(b"x = 1\n", True))
-            await feedback_send.send_all(b"\n")  # blank line: should be skipped
             reader = LineReader(query_recv)
-            line = await reader.readline()
-            assert line is not None
-            content = decode_query(line)
-            await feedback_send.send_all(encode_feedback(content, False))
+            await feedback_send.send_all(encode_reduce(b"x = 1\n"))
+            await feedback_send.send_all(b"\n")  # blank line: should be skipped
+            query_line = await reader.readline()
+            assert query_line is not None
+            query = parse_from_reducer(query_line)
+            assert isinstance(query, Query)
+            await feedback_send.send_all(encode_feedback(query.content, False))
+            idle_line = await reader.readline()
+            assert idle_line is not None
+            assert isinstance(parse_from_reducer(idle_line), Idle)
             await feedback_send.aclose()

--- a/tests/test_external_driver.py
+++ b/tests/test_external_driver.py
@@ -1,0 +1,205 @@
+"""Unit tests for the external reducer driver (RemoteReductionProblem)."""
+
+import trio
+from trio.testing import memory_stream_one_way_pair, wait_all_tasks_blocked
+
+from shrinkray.problem import ReductionProblem, sort_key_for_initial
+from shrinkray.reducers.driver import RemoteReductionProblem, run_reducer
+from shrinkray.reducers.protocol import (
+    LineReader,
+    decode_query,
+    encode_feedback,
+)
+from shrinkray.work import WorkContext
+
+
+class CollectingSendStream(trio.abc.SendStream):
+    """A minimal send stream that records everything sent to it."""
+
+    def __init__(self) -> None:
+        self.sent = bytearray()
+
+    async def send_all(self, data: bytes | bytearray | memoryview) -> None:
+        await trio.lowlevel.checkpoint()
+        self.sent.extend(data)
+
+    async def wait_send_all_might_not_block(self) -> None:
+        await trio.lowlevel.checkpoint()
+
+    async def aclose(self) -> None:
+        await trio.lowlevel.checkpoint()
+
+
+def make_problem(initial: bytes = b"hello world\n") -> RemoteReductionProblem:
+    return RemoteReductionProblem(
+        initial,
+        send_stream=CollectingSendStream(),
+        work=WorkContext(parallelism=1),
+        sort_key=sort_key_for_initial(initial),
+    )
+
+
+# === Basic properties ===
+
+
+def test_properties() -> None:
+    problem = make_problem(b"abc")
+    assert problem.current_test_case == b"abc"
+    assert problem.size(b"abcd") == 4
+    assert problem.display(b"abc") == repr(b"abc")
+    assert problem.stats.initial_test_case_size == 3
+    assert problem.sort_key(b"a") < problem.sort_key(b"ab")
+
+
+def test_handle_feedback_adopts_smaller_interesting() -> None:
+    problem = make_problem(b"hello world\n")
+    problem.handle_feedback(b"hi\n", True)
+    assert problem.current_test_case == b"hi\n"
+    assert problem.stats.reductions == 1
+    assert problem.stats.current_test_case_size == 3
+
+
+def test_handle_feedback_ignores_larger() -> None:
+    problem = make_problem(b"hi\n")
+    problem.handle_feedback(b"a much longer thing\n", True)
+    assert problem.current_test_case == b"hi\n"
+
+
+def test_handle_feedback_ignores_uninteresting() -> None:
+    problem = make_problem(b"hello world\n")
+    problem.handle_feedback(b"hi\n", False)
+    assert problem.current_test_case == b"hello world\n"
+
+
+# === is_interesting ===
+
+
+async def test_is_interesting_returns_true_for_current() -> None:
+    problem = make_problem(b"abc")
+    # No query is sent for the current test case.
+    assert await problem.is_interesting(b"abc") is True
+    assert problem._send_stream.sent == b""  # type: ignore[attr-defined]
+
+
+async def test_is_interesting_awaits_feedback() -> None:
+    problem = make_problem(b"hello world\n")
+
+    async with trio.open_nursery() as nursery:
+        results: list[bool] = []
+
+        @nursery.start_soon
+        async def _() -> None:
+            results.append(await problem.is_interesting(b"smaller\n"))
+
+        await wait_all_tasks_blocked()
+        # The query was sent, and the call is now blocked awaiting feedback.
+        assert decode_query(bytes(problem._send_stream.sent)) == b"smaller\n"  # type: ignore[attr-defined]
+        problem.handle_feedback(b"smaller\n", True)
+
+    assert results == [True]
+    assert problem.current_test_case == b"smaller\n"
+
+
+async def test_is_interesting_caches_results() -> None:
+    problem = make_problem(b"hello world\n")
+
+    async with trio.open_nursery() as nursery:
+
+        @nursery.start_soon
+        async def _() -> None:
+            assert await problem.is_interesting(b"nope-not-smaller-enough\n") is False
+
+        await wait_all_tasks_blocked()
+        problem.handle_feedback(b"nope-not-smaller-enough\n", False)
+
+    # A second call returns the cached result without sending another query.
+    sent_before = bytes(problem._send_stream.sent)  # type: ignore[attr-defined]
+    assert await problem.is_interesting(b"nope-not-smaller-enough\n") is False
+    assert bytes(problem._send_stream.sent) == sent_before  # type: ignore[attr-defined]
+
+
+async def test_is_interesting_returns_false_when_closed() -> None:
+    problem = make_problem(b"hello world\n")
+    problem.close()
+    assert await problem.is_interesting(b"anything\n") is False
+
+
+async def test_duplicate_concurrent_queries_all_resolve() -> None:
+    problem = make_problem(b"hello world\n")
+
+    async with trio.open_nursery() as nursery:
+        results: list[bool] = []
+
+        for _ in range(2):
+
+            @nursery.start_soon
+            async def query_task() -> None:
+                results.append(await problem.is_interesting(b"dup\n"))
+
+        await wait_all_tasks_blocked()
+        # Two feedback messages resolve the two outstanding duplicate queries.
+        problem.handle_feedback(b"dup\n", False)
+        await wait_all_tasks_blocked()
+        problem.handle_feedback(b"dup\n", False)
+
+    assert results == [False, False]
+
+
+async def test_close_fails_outstanding_waiters() -> None:
+    problem = make_problem(b"hello world\n")
+
+    async with trio.open_nursery() as nursery:
+        results: list[bool] = []
+
+        @nursery.start_soon
+        async def _() -> None:
+            results.append(await problem.is_interesting(b"pending\n"))
+
+        await wait_all_tasks_blocked()
+        problem.close()
+
+    assert results == [False]
+
+
+# === run_reducer edges ===
+
+
+async def test_run_reducer_returns_on_empty_handshake() -> None:
+    """If shrink ray closes the stream before the handshake, we just return."""
+    feedback_send, feedback_recv = memory_stream_one_way_pair()
+    _query_send, query_recv = memory_stream_one_way_pair()
+    await feedback_send.aclose()  # immediate EOF, no handshake
+
+    await run_reducer([], stdin_stream=feedback_recv, stdout_stream=_query_send)
+    await query_recv.aclose()
+
+
+async def test_run_reducer_skips_blank_feedback_lines() -> None:
+    """Blank feedback lines are ignored by the reducer's feedback reader."""
+    feedback_send, feedback_recv = memory_stream_one_way_pair()
+    query_send, query_recv = memory_stream_one_way_pair()
+
+    async def one_shot(problem: ReductionProblem[bytes]) -> None:
+        await problem.is_interesting(b"y = 2\n")
+
+    async with trio.open_nursery() as nursery:
+
+        @nursery.start_soon
+        async def _reducer() -> None:
+            await run_reducer(
+                [one_shot],
+                stdin_stream=feedback_recv,
+                stdout_stream=query_send,
+            )
+            await query_send.aclose()
+
+        @nursery.start_soon
+        async def _shrinkray() -> None:
+            await feedback_send.send_all(encode_feedback(b"x = 1\n", True))
+            await feedback_send.send_all(b"\n")  # blank line: should be skipped
+            reader = LineReader(query_recv)
+            line = await reader.readline()
+            assert line is not None
+            content = decode_query(line)
+            await feedback_send.send_all(encode_feedback(content, False))
+            await feedback_send.aclose()

--- a/tests/test_external_protocol.py
+++ b/tests/test_external_protocol.py
@@ -7,11 +7,19 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from shrinkray.reducers.protocol import (
+    Feedback,
+    Idle,
     LineReader,
+    Query,
+    ReduceRequest,
     decode_feedback,
     decode_query,
     encode_feedback,
+    encode_idle,
     encode_query,
+    encode_reduce,
+    parse_from_reducer,
+    parse_to_reducer,
 )
 
 
@@ -81,6 +89,48 @@ def test_decode_feedback_rejects_missing_interesting() -> None:
     content = base64.b64encode(b"x").decode()
     with pytest.raises(ValueError):
         decode_feedback(json.dumps({"content": content}))
+
+
+# === reduce / idle + message classification ===
+
+
+@given(st.binary())
+def test_parse_to_reducer_classifies_reduce(content: bytes) -> None:
+    assert parse_to_reducer(encode_reduce(content)) == ReduceRequest(content)
+
+
+@given(st.binary(), st.booleans())
+def test_parse_to_reducer_classifies_feedback(content: bytes, ok: bool) -> None:
+    assert parse_to_reducer(encode_feedback(content, ok)) == Feedback(content, ok)
+
+
+def test_parse_to_reducer_rejects_unknown() -> None:
+    with pytest.raises(ValueError):
+        parse_to_reducer(json.dumps({"nope": 1}))
+
+
+def test_parse_to_reducer_rejects_non_object() -> None:
+    with pytest.raises(ValueError):
+        parse_to_reducer(b"[1, 2]")
+
+
+@given(st.binary())
+def test_parse_from_reducer_classifies_query(content: bytes) -> None:
+    assert parse_from_reducer(encode_query(content)) == Query(content)
+
+
+def test_parse_from_reducer_classifies_idle() -> None:
+    assert parse_from_reducer(encode_idle()) == Idle()
+
+
+def test_parse_from_reducer_rejects_unknown() -> None:
+    with pytest.raises(ValueError):
+        parse_from_reducer(json.dumps({"nope": 1}))
+
+
+def test_parse_from_reducer_rejects_non_object() -> None:
+    with pytest.raises(ValueError):
+        parse_from_reducer(b"42")
 
 
 # === LineReader ===

--- a/tests/test_external_protocol.py
+++ b/tests/test_external_protocol.py
@@ -1,0 +1,133 @@
+import base64
+import json
+
+import pytest
+import trio
+from hypothesis import given
+from hypothesis import strategies as st
+
+from shrinkray.reducers.protocol import (
+    LineReader,
+    decode_feedback,
+    decode_query,
+    encode_feedback,
+    encode_query,
+)
+
+
+# === Query encode/decode ===
+
+
+@given(st.binary())
+def test_query_round_trip(content: bytes) -> None:
+    line = encode_query(content)
+    assert line.endswith(b"\n")
+    assert decode_query(line) == content
+
+
+def test_query_line_is_single_line() -> None:
+    line = encode_query(b"a\nb\nc")
+    # The newline in the content must not leak into the transport framing.
+    assert line.count(b"\n") == 1
+
+
+def test_decode_query_rejects_non_object() -> None:
+    with pytest.raises(ValueError):
+        decode_query(b"[1, 2, 3]")
+
+
+def test_decode_query_rejects_missing_content() -> None:
+    with pytest.raises(ValueError):
+        decode_query(json.dumps({"nope": 1}))
+
+
+def test_decode_query_rejects_invalid_json() -> None:
+    with pytest.raises(ValueError):
+        decode_query(b"not json")
+
+
+# === Feedback encode/decode ===
+
+
+@given(st.binary(), st.booleans())
+def test_feedback_round_trip(content: bytes, interesting: bool) -> None:
+    line = encode_feedback(content, interesting)
+    assert line.endswith(b"\n")
+    assert decode_feedback(line) == (content, interesting)
+
+
+def test_feedback_line_is_single_line() -> None:
+    line = encode_feedback(b"x\ny", True)
+    assert line.count(b"\n") == 1
+
+
+def test_encode_feedback_coerces_truthy_to_bool() -> None:
+    line = encode_feedback(b"", 1)  # type: ignore[arg-type]
+    obj = json.loads(line)
+    assert obj["interesting"] is True
+
+
+def test_decode_feedback_rejects_non_object() -> None:
+    with pytest.raises(ValueError):
+        decode_feedback(b'"a string"')
+
+
+def test_decode_feedback_rejects_missing_content() -> None:
+    with pytest.raises(ValueError):
+        decode_feedback(json.dumps({"interesting": True}))
+
+
+def test_decode_feedback_rejects_missing_interesting() -> None:
+    content = base64.b64encode(b"x").decode()
+    with pytest.raises(ValueError):
+        decode_feedback(json.dumps({"content": content}))
+
+
+# === LineReader ===
+
+
+class ChunkStream:
+    """A fake receive stream that yields a fixed list of chunks then EOF."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = list(chunks)
+
+    async def receive_some(self, max_bytes: int | None = None) -> bytes:
+        await trio.lowlevel.checkpoint()
+        if self._chunks:
+            return self._chunks.pop(0)
+        return b""
+
+
+async def test_line_reader_splits_lines() -> None:
+    reader = LineReader(ChunkStream([b"one\ntwo\nthree\n"]))
+    assert await reader.readline() == b"one"
+    assert await reader.readline() == b"two"
+    assert await reader.readline() == b"three"
+    assert await reader.readline() is None
+
+
+async def test_line_reader_reassembles_partial_chunks() -> None:
+    reader = LineReader(ChunkStream([b"he", b"ll", b"o\nwor", b"ld\n"]))
+    assert await reader.readline() == b"hello"
+    assert await reader.readline() == b"world"
+    assert await reader.readline() is None
+
+
+async def test_line_reader_returns_trailing_line_without_newline() -> None:
+    reader = LineReader(ChunkStream([b"a\nb"]))
+    assert await reader.readline() == b"a"
+    assert await reader.readline() == b"b"
+    assert await reader.readline() is None
+
+
+async def test_line_reader_immediate_eof() -> None:
+    reader = LineReader(ChunkStream([]))
+    assert await reader.readline() is None
+
+
+async def test_line_reader_handles_blank_lines() -> None:
+    reader = LineReader(ChunkStream([b"\n\n"]))
+    assert await reader.readline() == b""
+    assert await reader.readline() == b""
+    assert await reader.readline() is None

--- a/tests/test_external_protocol.py
+++ b/tests/test_external_protocol.py
@@ -7,19 +7,15 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from shrinkray.reducers.protocol import (
-    Feedback,
     Idle,
     LineReader,
     Query,
-    ReduceRequest,
     decode_feedback,
     decode_query,
     encode_feedback,
     encode_idle,
     encode_query,
-    encode_reduce,
     parse_from_reducer,
-    parse_to_reducer,
 )
 
 
@@ -91,27 +87,7 @@ def test_decode_feedback_rejects_missing_interesting() -> None:
         decode_feedback(json.dumps({"content": content}))
 
 
-# === reduce / idle + message classification ===
-
-
-@given(st.binary())
-def test_parse_to_reducer_classifies_reduce(content: bytes) -> None:
-    assert parse_to_reducer(encode_reduce(content)) == ReduceRequest(content)
-
-
-@given(st.binary(), st.booleans())
-def test_parse_to_reducer_classifies_feedback(content: bytes, ok: bool) -> None:
-    assert parse_to_reducer(encode_feedback(content, ok)) == Feedback(content, ok)
-
-
-def test_parse_to_reducer_rejects_unknown() -> None:
-    with pytest.raises(ValueError):
-        parse_to_reducer(json.dumps({"nope": 1}))
-
-
-def test_parse_to_reducer_rejects_non_object() -> None:
-    with pytest.raises(ValueError):
-        parse_to_reducer(b"[1, 2]")
+# === idle + reducer-message classification ===
 
 
 @given(st.binary())

--- a/tests/test_external_reducer.py
+++ b/tests/test_external_reducer.py
@@ -1,0 +1,403 @@
+"""In-process tests for the external reducer machinery.
+
+These connect the reducer side (``run_reducer`` / ``RemoteReductionProblem``)
+to the shrink-ray side (``drive_external_reducer``) over trio memory streams,
+with no subprocess involved. This exercises the whole protocol quickly.
+"""
+
+import os
+import runpy
+import sys
+from collections.abc import Callable, Iterable
+from unittest.mock import patch
+
+import pytest
+import trio
+from trio.testing import memory_stream_one_way_pair
+
+from shrinkray.passes.definitions import ReductionPass
+from shrinkray.passes.external import drive_external_reducer, external_reducer
+from shrinkray.passes.python import PYTHON_PASSES, python_reducer_command
+from shrinkray.problem import BasicReductionProblem, sort_key_for_initial
+from shrinkray.reducers import python as python_reducer_module
+from shrinkray.reducers.driver import run_reducer
+from shrinkray.reducers.protocol import (
+    LineReader,
+    decode_feedback,
+    encode_feedback,
+    encode_query,
+)
+from shrinkray.work import WorkContext
+from tests.helpers import reduce_with
+
+
+def make_basic_problem(
+    initial: bytes, is_interesting: Callable[[bytes], bool], parallelism: int = 1
+) -> BasicReductionProblem[bytes]:
+    async def acondition(x: bytes) -> bool:
+        await trio.lowlevel.checkpoint()
+        return is_interesting(x)
+
+    return BasicReductionProblem(
+        initial=initial,
+        is_interesting=acondition,
+        work=WorkContext(parallelism=parallelism),
+        sort_key=sort_key_for_initial(initial),
+    )
+
+
+def reduce_externally(
+    passes: Iterable[ReductionPass[bytes]],
+    initial: bytes,
+    is_interesting: Callable[[bytes], bool],
+    parallelism: int = 1,
+) -> bytes:
+    """Synchronous wrapper around :func:`run_connected`."""
+    return trio.run(run_connected, passes, initial, is_interesting, parallelism)
+
+
+async def run_connected(
+    passes: Iterable[ReductionPass[bytes]],
+    initial: bytes,
+    is_interesting: Callable[[bytes], bool],
+    parallelism: int = 1,
+) -> bytes:
+    """Reduce ``initial`` by driving ``passes`` as an external reducer.
+
+    Returns the shrink-ray side's final test case. The reducer runs the given
+    passes against a RemoteReductionProblem; the shrink-ray side answers with a
+    real BasicReductionProblem wrapping ``is_interesting``.
+    """
+    passes = list(passes)
+
+    async def acondition(x: bytes) -> bool:
+        await trio.lowlevel.checkpoint()
+        return is_interesting(x)
+
+    problem: BasicReductionProblem[bytes] = BasicReductionProblem(
+        initial=initial,
+        is_interesting=acondition,
+        work=WorkContext(parallelism=parallelism),
+        sort_key=sort_key_for_initial(initial),
+    )
+
+    # feedback: shrink ray -> reducer; queries: reducer -> shrink ray
+    feedback_send, feedback_recv = memory_stream_one_way_pair()
+    query_send, query_recv = memory_stream_one_way_pair()
+
+    async with trio.open_nursery() as nursery:
+
+        @nursery.start_soon
+        async def _reducer() -> None:
+            await run_reducer(
+                passes,
+                stdin_stream=feedback_recv,
+                stdout_stream=query_send,
+                parallelism=parallelism,
+            )
+            # Signal EOF so the shrink-ray side stops waiting for queries.
+            await query_send.aclose()
+
+        @nursery.start_soon
+        async def _shrinkray() -> None:
+            await drive_external_reducer(
+                problem,
+                send_stream=feedback_send,
+                recv_stream=query_recv,
+                timeout=30.0,
+                parallelism=parallelism,
+            )
+            await feedback_send.aclose()
+
+    return problem.current_test_case
+
+
+ANNOTATED = b"""
+def has_an_annotation(x: list[int]) -> list[int]:
+    y: list[int] = list(reversed(x))
+    return x + y
+"""
+
+
+@pytest.mark.parametrize("parallelism", [1, 2])
+def test_matches_in_process_reduction(parallelism: int) -> None:
+    """Driving PYTHON_PASSES externally matches running them in-process."""
+
+    def is_interesting(x: bytes) -> bool:
+        return b"return" in x
+
+    expected = reduce_with(
+        PYTHON_PASSES, ANNOTATED, is_interesting, parallelism=parallelism
+    )
+    got = reduce_externally(
+        PYTHON_PASSES, ANNOTATED, is_interesting, parallelism=parallelism
+    )
+    assert got == expected
+
+
+def test_reduces_annotations_away() -> None:
+    """A trivially-true predicate strips annotations and stubs the body."""
+    got = reduce_externally(PYTHON_PASSES, ANNOTATED, lambda x: True)
+    assert b"list[int]" not in got  # annotations gone
+    assert b"..." in got  # body stubbed out
+
+
+def test_reducer_with_no_progress_terminates() -> None:
+    """If nothing is interesting below the initial, the reducer still exits."""
+    initial = b"x = 1\n"
+    got = reduce_externally(PYTHON_PASSES, initial, lambda x: x == initial)
+    assert got == initial
+
+
+# === Real subprocess: the built-in Python reducer ===
+
+
+def reduce_with_real_subprocess(
+    initial: bytes,
+    is_interesting: Callable[[bytes], bool],
+    parallelism: int = 1,
+    tmp_path: str | None = None,
+) -> bytes:
+    """Reduce ``initial`` by launching the real python reducer subprocess."""
+
+    async def acondition(x: bytes) -> bool:
+        await trio.lowlevel.checkpoint()
+        return is_interesting(x)
+
+    log_file = os.path.join(tmp_path, "reducer.log") if tmp_path else None
+    reducer_pass = external_reducer(python_reducer_command(), log_file=log_file)
+
+    async def run() -> bytes:
+        problem: BasicReductionProblem[bytes] = BasicReductionProblem(
+            initial=initial,
+            is_interesting=acondition,
+            work=WorkContext(parallelism=parallelism),
+            sort_key=sort_key_for_initial(initial),
+        )
+        await reducer_pass(problem)
+        return problem.current_test_case
+
+    return trio.run(run)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("parallelism", [1, 2])
+def test_real_python_reducer_subprocess(parallelism: int, tmp_path) -> None:
+    """The built-in Python reducer, run as a real subprocess, reduces Python."""
+
+    def is_interesting(x: bytes) -> bool:
+        return b"return" in x
+
+    expected = reduce_with(PYTHON_PASSES, ANNOTATED, is_interesting)
+    got = reduce_with_real_subprocess(
+        ANNOTATED, is_interesting, parallelism=parallelism, tmp_path=str(tmp_path)
+    )
+    assert got == expected
+
+
+@pytest.mark.slow
+def test_real_python_reducer_writes_log(tmp_path) -> None:
+    """The reducer's stderr is captured to the given log file."""
+    log_file = tmp_path / "reducer.log"
+    reduce_with_real_subprocess(
+        ANNOTATED, lambda x: b"return" in x, tmp_path=str(tmp_path)
+    )
+    # The log file is created even if the reducer logs nothing.
+    assert log_file.exists()
+
+
+# === reducers.python serve()/main() coverage ===
+
+
+def test_python_reducer_serve_over_pipes() -> None:
+    """serve() wires stdin/stdout fds up to run_reducer and returns at EOF."""
+    # shrink ray -> reducer (its stdin); reducer -> shrink ray (its stdout)
+    feedback_read, feedback_write = os.pipe()
+    query_read, query_write = os.pipe()
+
+    # Send only the handshake, then close, so the reducer sees EOF and exits.
+    os.write(feedback_write, encode_feedback(b"x = 1\n", True))
+    os.close(feedback_write)
+
+    def fake_dup(fd: int) -> int:
+        return {0: feedback_read, 1: query_write}[fd]
+
+    async def run() -> None:
+        with patch.object(python_reducer_module.os, "dup", fake_dup):
+            await python_reducer_module.serve(parallelism=1, seed=0)
+
+    trio.run(run)
+    # Drain whatever the reducer wrote so nothing is left dangling.
+    os.close(query_read)
+
+
+def test_python_reducer_main_reads_env_and_runs() -> None:
+    """main() reads parallelism/seed from the environment and runs serve()."""
+    seen: dict[str, int] = {}
+
+    async def fake_serve(parallelism: int, seed: int) -> None:
+        seen["parallelism"] = parallelism
+        seen["seed"] = seed
+
+    env = {"SHRINKRAY_REDUCER_PARALLELISM": "3", "SHRINKRAY_REDUCER_SEED": "7"}
+    with (
+        patch.dict(os.environ, env),
+        patch.object(python_reducer_module, "serve", fake_serve),
+    ):
+        python_reducer_module.main()
+    assert seen == {"parallelism": 3, "seed": 7}
+
+
+def test_python_reducer_main_defaults() -> None:
+    """main() defaults to parallelism 1 and seed 0 with no environment."""
+    seen: dict[str, int] = {}
+
+    async def fake_serve(parallelism: int, seed: int) -> None:
+        seen["parallelism"] = parallelism
+        seen["seed"] = seed
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch.object(python_reducer_module, "serve", fake_serve),
+    ):
+        python_reducer_module.main()
+    assert seen == {"parallelism": 1, "seed": 0}
+
+
+def test_python_reducer_module_entry_point() -> None:
+    """Running the module as __main__ invokes main()."""
+    with patch("shrinkray.reducers.python.trio.run") as mock_trio_run:
+        runpy.run_module(
+            "shrinkray.reducers.python", run_name="__main__", alter_sys=True
+        )
+    assert mock_trio_run.called
+
+
+# === drive_external_reducer edge cases (no subprocess) ===
+
+
+async def test_drive_ignores_blank_and_malformed_queries() -> None:
+    """Blank and malformed query lines are skipped; valid ones are answered."""
+    problem = make_basic_problem(b"hello world\n", lambda x: b"h" in x)
+
+    fb_send, fb_recv = memory_stream_one_way_pair()
+    q_send, q_recv = memory_stream_one_way_pair()
+
+    async with trio.open_nursery() as nursery:
+
+        @nursery.start_soon
+        async def _shrinkray() -> None:
+            await drive_external_reducer(
+                problem,
+                send_stream=fb_send,
+                recv_stream=q_recv,
+                timeout=5.0,
+                parallelism=1,
+            )
+
+        @nursery.start_soon
+        async def _reducer() -> None:
+            reader = LineReader(fb_recv)
+            await reader.readline()  # consume the handshake
+            await q_send.send_all(b"\n")  # blank: skipped
+            await q_send.send_all(b"garbage not json\n")  # malformed: skipped
+            await q_send.send_all(encode_query(b"h\n"))  # valid
+            line = await reader.readline()
+            assert line is not None
+            content, interesting = decode_feedback(line)
+            assert content == b"h\n"
+            assert interesting is True
+            await q_send.aclose()  # EOF -> drive returns
+
+
+async def test_drive_times_out_when_reducer_is_silent() -> None:
+    """If the reducer sends no query within the timeout, drive returns."""
+    problem = make_basic_problem(b"hello\n", lambda x: True)
+
+    fb_send, _fb_recv = memory_stream_one_way_pair()
+    _q_send, q_recv = memory_stream_one_way_pair()
+
+    # q_recv never receives data and is never closed; the timeout must fire.
+    with trio.fail_after(5):
+        await drive_external_reducer(
+            problem,
+            send_stream=fb_send,
+            recv_stream=q_recv,
+            timeout=0.05,
+            parallelism=1,
+        )
+
+
+async def test_drive_tolerates_broken_send_stream() -> None:
+    """A broken feedback stream (reducer gone) does not raise out of drive."""
+    problem = make_basic_problem(b"hello\n", lambda x: True)
+
+    fb_send, fb_recv = memory_stream_one_way_pair()
+    q_send, q_recv = memory_stream_one_way_pair()
+    await fb_recv.aclose()  # sending feedback will now break
+    await q_send.aclose()  # query stream is at EOF
+
+    # Handshake send raises BrokenResourceError internally; it is swallowed and
+    # the loop then sees EOF and returns cleanly.
+    await drive_external_reducer(
+        problem,
+        send_stream=fb_send,
+        recv_stream=q_recv,
+        timeout=5.0,
+        parallelism=1,
+    )
+
+
+# === external_reducer factory (fast subprocesses) ===
+
+
+async def test_external_reducer_launches_and_terminates() -> None:
+    """A reducer that reads the handshake and exits is handled cleanly."""
+    problem = make_basic_problem(b"hello\n", lambda x: True)
+    command = [sys.executable, "-c", "import sys; sys.stdin.readline()"]
+    reducer_pass = external_reducer(command, log_file=None)
+    with trio.fail_after(30):
+        await reducer_pass(problem)
+
+
+async def test_external_reducer_passes_extra_env(tmp_path) -> None:
+    """extra_env is added to the reducer subprocess's environment."""
+    problem = make_basic_problem(b"hello\n", lambda x: True)
+    log_file = tmp_path / "reducer.log"
+    command = [
+        sys.executable,
+        "-c",
+        "import sys, os; sys.stderr.write(os.environ['SHRINKRAY_TEST_VAR']); "
+        "sys.stdin.readline()",
+    ]
+    reducer_pass = external_reducer(
+        command, log_file=str(log_file), extra_env={"SHRINKRAY_TEST_VAR": "custom"}
+    )
+    with trio.fail_after(30):
+        await reducer_pass(problem)
+    assert b"custom" in log_file.read_bytes()
+
+
+async def test_external_reducer_writes_stderr_to_log(tmp_path) -> None:
+    """The reducer's stderr is appended to the log file."""
+    problem = make_basic_problem(b"hello\n", lambda x: True)
+    log_file = tmp_path / "reducer.log"
+    command = [
+        sys.executable,
+        "-c",
+        "import sys; sys.stderr.write('hello from reducer'); sys.stdin.readline()",
+    ]
+    reducer_pass = external_reducer(command, log_file=str(log_file))
+    with trio.fail_after(30):
+        await reducer_pass(problem)
+    assert b"hello from reducer" in log_file.read_bytes()
+
+
+def test_external_reducer_default_name_from_command() -> None:
+    reducer_pass = external_reducer([sys.executable, "-c", "pass"])
+    assert reducer_pass.__name__ == f"external:{os.path.basename(sys.executable)}"
+
+
+def test_external_reducer_custom_name() -> None:
+    reducer_pass = external_reducer([sys.executable], name="my-reducer")
+    assert reducer_pass.__name__ == "my-reducer"

--- a/tests/test_external_reducer.py
+++ b/tests/test_external_reducer.py
@@ -23,12 +23,10 @@ from shrinkray.reducers import python as python_reducer_module
 from shrinkray.reducers.driver import run_reducer
 from shrinkray.reducers.protocol import (
     LineReader,
-    ReduceRequest,
     decode_feedback,
+    encode_feedback,
     encode_idle,
     encode_query,
-    encode_reduce,
-    parse_to_reducer,
 )
 from shrinkray.work import WorkContext
 from tests.helpers import reduce_with
@@ -226,8 +224,8 @@ def test_python_reducer_serve_over_pipes() -> None:
     feedback_read, feedback_write = os.pipe()
     query_read, query_write = os.pipe()
 
-    # Send one reduce request, then close, so the reducer sees EOF and exits.
-    os.write(feedback_write, encode_reduce(b"x = 1\n"))
+    # Send one test case, then close, so the reducer sees EOF and exits.
+    os.write(feedback_write, encode_feedback(b"x = 1\n", True))
     os.close(feedback_write)
 
     def fake_dup(fd: int) -> int:
@@ -314,10 +312,12 @@ async def test_drive_ignores_blank_and_malformed_queries() -> None:
         @nursery.start_soon
         async def _reducer() -> None:
             fb_reader = LineReader(fb_recv)
-            request_line = await fb_reader.readline()
-            assert request_line is not None
-            request = parse_to_reducer(request_line)
-            assert isinstance(request, ReduceRequest)
+            first_line = await fb_reader.readline()
+            assert first_line is not None
+            # The first message is the current test case, handed over as feedback.
+            content, interesting = decode_feedback(first_line)
+            assert content == b"hello world\n"
+            assert interesting is True
             await q_send.send_all(b"\n")  # blank: skipped
             await q_send.send_all(b"garbage not json\n")  # malformed: skipped
             await q_send.send_all(encode_query(b"h\n"))  # valid
@@ -418,8 +418,8 @@ async def test_external_reducer_writes_stderr_to_log(tmp_path) -> None:
     assert b"hello from reducer" in log_file.read_bytes()
 
 
-# A trivial persistent reducer: for each reduce request it immediately reports
-# idle (and never queries), staying alive until its stdin closes.
+# A trivial persistent reducer: for each test case it is handed it immediately
+# reports idle (and never queries), staying alive until its stdin closes.
 _IDLE_REDUCER = (
     "import sys, json\n"
     "for line in sys.stdin:\n"
@@ -427,7 +427,7 @@ _IDLE_REDUCER = (
     "    if not line:\n"
     "        continue\n"
     "    obj = json.loads(line)\n"
-    "    if 'reduce' in obj:\n"
+    "    if 'content' in obj:\n"
     "        sys.stdout.write('{\"idle\": true}\\n'); sys.stdout.flush()\n"
 )
 

--- a/tests/test_external_reducer.py
+++ b/tests/test_external_reducer.py
@@ -23,9 +23,12 @@ from shrinkray.reducers import python as python_reducer_module
 from shrinkray.reducers.driver import run_reducer
 from shrinkray.reducers.protocol import (
     LineReader,
+    ReduceRequest,
     decode_feedback,
-    encode_feedback,
+    encode_idle,
     encode_query,
+    encode_reduce,
+    parse_to_reducer,
 )
 from shrinkray.work import WorkContext
 from tests.helpers import reduce_with
@@ -81,9 +84,10 @@ async def run_connected(
         sort_key=sort_key_for_initial(initial),
     )
 
-    # feedback: shrink ray -> reducer; queries: reducer -> shrink ray
+    # feedback/reduce: shrink ray -> reducer; queries/idle: reducer -> shrink ray
     feedback_send, feedback_recv = memory_stream_one_way_pair()
     query_send, query_recv = memory_stream_one_way_pair()
+    reader = LineReader(query_recv)
 
     async with trio.open_nursery() as nursery:
 
@@ -100,13 +104,16 @@ async def run_connected(
 
         @nursery.start_soon
         async def _shrinkray() -> None:
-            await drive_external_reducer(
+            # One reduce request drives the reducer to a fixpoint.
+            alive = await drive_external_reducer(
                 problem,
                 send_stream=feedback_send,
-                recv_stream=query_recv,
+                reader=reader,
                 timeout=30.0,
                 parallelism=parallelism,
             )
+            assert alive  # the reducer reported idle, staying alive
+            # Close the request stream so the reducer exits.
             await feedback_send.aclose()
 
     return problem.current_test_case
@@ -174,8 +181,12 @@ def reduce_with_real_subprocess(
             work=WorkContext(parallelism=parallelism),
             sort_key=sort_key_for_initial(initial),
         )
-        await reducer_pass(problem)
-        return problem.current_test_case
+        try:
+            await reducer_pass(problem)
+            return problem.current_test_case
+        finally:
+            # The reducer stays alive between calls, so tear it down explicitly.
+            await reducer_pass.aclose()
 
     return trio.run(run)
 
@@ -215,8 +226,8 @@ def test_python_reducer_serve_over_pipes() -> None:
     feedback_read, feedback_write = os.pipe()
     query_read, query_write = os.pipe()
 
-    # Send only the handshake, then close, so the reducer sees EOF and exits.
-    os.write(feedback_write, encode_feedback(b"x = 1\n", True))
+    # Send one reduce request, then close, so the reducer sees EOF and exits.
+    os.write(feedback_write, encode_reduce(b"x = 1\n"))
     os.close(feedback_write)
 
     def fake_dup(fd: int) -> int:
@@ -277,87 +288,101 @@ def test_python_reducer_module_entry_point() -> None:
 
 
 async def test_drive_ignores_blank_and_malformed_queries() -> None:
-    """Blank and malformed query lines are skipped; valid ones are answered."""
+    """Blank and malformed lines are skipped; valid queries are answered; idle
+    ends the request with the reducer still alive."""
     problem = make_basic_problem(b"hello world\n", lambda x: b"h" in x)
 
     fb_send, fb_recv = memory_stream_one_way_pair()
     q_send, q_recv = memory_stream_one_way_pair()
+    reader = LineReader(q_recv)
+
+    result: list[bool] = []
 
     async with trio.open_nursery() as nursery:
 
         @nursery.start_soon
         async def _shrinkray() -> None:
-            await drive_external_reducer(
+            alive = await drive_external_reducer(
                 problem,
                 send_stream=fb_send,
-                recv_stream=q_recv,
+                reader=reader,
                 timeout=5.0,
                 parallelism=1,
             )
+            result.append(alive)
 
         @nursery.start_soon
         async def _reducer() -> None:
-            reader = LineReader(fb_recv)
-            await reader.readline()  # consume the handshake
+            fb_reader = LineReader(fb_recv)
+            request_line = await fb_reader.readline()
+            assert request_line is not None
+            request = parse_to_reducer(request_line)
+            assert isinstance(request, ReduceRequest)
             await q_send.send_all(b"\n")  # blank: skipped
             await q_send.send_all(b"garbage not json\n")  # malformed: skipped
             await q_send.send_all(encode_query(b"h\n"))  # valid
-            line = await reader.readline()
+            line = await fb_reader.readline()
             assert line is not None
             content, interesting = decode_feedback(line)
             assert content == b"h\n"
             assert interesting is True
-            await q_send.aclose()  # EOF -> drive returns
+            await q_send.send_all(encode_idle())  # reducer done for now
+
+    assert result == [True]
 
 
-async def test_drive_times_out_when_reducer_is_silent() -> None:
-    """If the reducer sends no query within the timeout, drive returns."""
+async def test_drive_returns_false_on_timeout() -> None:
+    """If the reducer sends nothing within the timeout, drive returns False."""
     problem = make_basic_problem(b"hello\n", lambda x: True)
 
     fb_send, _fb_recv = memory_stream_one_way_pair()
     _q_send, q_recv = memory_stream_one_way_pair()
+    reader = LineReader(q_recv)
 
-    # q_recv never receives data and is never closed; the timeout must fire.
     with trio.fail_after(5):
-        await drive_external_reducer(
+        alive = await drive_external_reducer(
             problem,
             send_stream=fb_send,
-            recv_stream=q_recv,
+            reader=reader,
             timeout=0.05,
             parallelism=1,
         )
+    assert alive is False
 
 
-async def test_drive_tolerates_broken_send_stream() -> None:
-    """A broken feedback stream (reducer gone) does not raise out of drive."""
+async def test_drive_returns_false_and_tolerates_broken_send() -> None:
+    """A broken send stream is swallowed and EOF returns False."""
     problem = make_basic_problem(b"hello\n", lambda x: True)
 
     fb_send, fb_recv = memory_stream_one_way_pair()
     q_send, q_recv = memory_stream_one_way_pair()
-    await fb_recv.aclose()  # sending feedback will now break
-    await q_send.aclose()  # query stream is at EOF
+    reader = LineReader(q_recv)
+    await fb_recv.aclose()  # sending the reduce request will now break
+    await q_send.aclose()  # reducer output stream is at EOF
 
-    # Handshake send raises BrokenResourceError internally; it is swallowed and
-    # the loop then sees EOF and returns cleanly.
-    await drive_external_reducer(
+    alive = await drive_external_reducer(
         problem,
         send_stream=fb_send,
-        recv_stream=q_recv,
+        reader=reader,
         timeout=5.0,
         parallelism=1,
     )
+    assert alive is False
 
 
 # === external_reducer factory (fast subprocesses) ===
 
 
 async def test_external_reducer_launches_and_terminates() -> None:
-    """A reducer that reads the handshake and exits is handled cleanly."""
+    """A reducer that reads its first request and exits is handled cleanly."""
     problem = make_basic_problem(b"hello\n", lambda x: True)
     command = [sys.executable, "-c", "import sys; sys.stdin.readline()"]
     reducer_pass = external_reducer(command, log_file=None)
-    with trio.fail_after(30):
-        await reducer_pass(problem)
+    try:
+        with trio.fail_after(30):
+            await reducer_pass(problem)
+    finally:
+        await reducer_pass.aclose()
 
 
 async def test_external_reducer_passes_extra_env(tmp_path) -> None:
@@ -391,6 +416,44 @@ async def test_external_reducer_writes_stderr_to_log(tmp_path) -> None:
     with trio.fail_after(30):
         await reducer_pass(problem)
     assert b"hello from reducer" in log_file.read_bytes()
+
+
+# A trivial persistent reducer: for each reduce request it immediately reports
+# idle (and never queries), staying alive until its stdin closes.
+_IDLE_REDUCER = (
+    "import sys, json\n"
+    "for line in sys.stdin:\n"
+    "    line = line.strip()\n"
+    "    if not line:\n"
+    "        continue\n"
+    "    obj = json.loads(line)\n"
+    "    if 'reduce' in obj:\n"
+    "        sys.stdout.write('{\"idle\": true}\\n'); sys.stdout.flush()\n"
+)
+
+
+async def test_external_reducer_reuses_persistent_subprocess() -> None:
+    """A reducer that goes idle stays alive and is reused on the next call."""
+    problem = make_basic_problem(b"hello\n", lambda x: True)
+    reducer_pass = external_reducer([sys.executable, "-c", _IDLE_REDUCER])
+    try:
+        with trio.fail_after(30):
+            await reducer_pass(problem)
+            first_proc = reducer_pass._proc
+            assert first_proc is not None  # stayed alive after going idle
+            await reducer_pass(problem)
+            assert reducer_pass._proc is first_proc  # reused, not relaunched
+    finally:
+        await reducer_pass.aclose()
+    assert reducer_pass._proc is None  # torn down by aclose
+
+
+async def test_external_reducer_launch_failure_propagates() -> None:
+    """If the reducer command cannot be launched, the error propagates."""
+    problem = make_basic_problem(b"hello\n", lambda x: True)
+    reducer_pass = external_reducer(["/nonexistent/shrinkray-reducer-xyz"])
+    with pytest.raises(OSError):
+        await reducer_pass(problem)
 
 
 def test_external_reducer_default_name_from_command() -> None:

--- a/tests/test_external_wiring.py
+++ b/tests/test_external_wiring.py
@@ -1,0 +1,111 @@
+"""Tests for wiring external reducers into ShrinkRay and the state layer."""
+
+import os
+
+import trio
+
+from shrinkray.problem import BasicReductionProblem, sort_key_for_initial
+from shrinkray.reducer import DirectoryShrinkRay, ShrinkRay
+from shrinkray.work import WorkContext
+
+
+def make_shrinkray(initial: bytes, **kwargs) -> ShrinkRay:
+    async def is_interesting(x: bytes) -> bool:
+        await trio.lowlevel.checkpoint()
+        return True
+
+    problem: BasicReductionProblem[bytes] = BasicReductionProblem(
+        initial=initial,
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+        sort_key=sort_key_for_initial(initial),
+    )
+    return ShrinkRay(target=problem, **kwargs)
+
+
+PYTHON_SOURCE = b"def f(x):\n    return x\n"
+NON_PYTHON = b"this is (not python at all;;;\n"
+
+
+# === build_external_reducer_passes ===
+
+
+def test_python_reducer_added_for_python_input():
+    reducer = make_shrinkray(PYTHON_SOURCE)
+    passes = reducer.build_external_reducer_passes()
+    assert [p.__name__ for p in passes] == ["python"]
+
+
+def test_python_reducer_not_added_when_disabled():
+    reducer = make_shrinkray(PYTHON_SOURCE, python_reducer=False)
+    assert reducer.build_external_reducer_passes() == []
+
+
+def test_python_reducer_not_added_for_non_python():
+    reducer = make_shrinkray(NON_PYTHON)
+    assert reducer.build_external_reducer_passes() == []
+
+
+def test_user_reducers_added_in_order():
+    reducer = make_shrinkray(
+        NON_PYTHON, external_reducers=[["cmd-a"], ["cmd-b", "arg"]]
+    )
+    passes = reducer.build_external_reducer_passes()
+    assert [p.__name__ for p in passes] == ["reduce-with-0", "reduce-with-1"]
+
+
+def test_python_and_user_reducers_combined():
+    reducer = make_shrinkray(PYTHON_SOURCE, external_reducers=[["cmd-a"]])
+    passes = reducer.build_external_reducer_passes()
+    assert [p.__name__ for p in passes] == ["python", "reduce-with-0"]
+
+
+def test_external_passes_registered_in_pass_lists():
+    reducer = make_shrinkray(PYTHON_SOURCE)
+    names = [p.__name__ for p in reducer.great_passes]
+    assert "python" in names
+    initial_names = [p.__name__ for p in reducer.initial_cuts]
+    assert "python" in initial_names
+
+
+# === _log_file_for ===
+
+
+def test_log_file_for_returns_none_without_dir():
+    reducer = make_shrinkray(PYTHON_SOURCE, reducer_log_dir=None)
+    assert reducer._log_file_for("python") is None
+
+
+def test_log_file_for_creates_dir_and_path(tmp_path):
+    log_dir = tmp_path / "logs"
+    reducer = make_shrinkray(PYTHON_SOURCE, reducer_log_dir=str(log_dir))
+    path = reducer._log_file_for("python")
+    assert path == os.path.join(str(log_dir), "reducer-python.log")
+    assert log_dir.is_dir()
+
+
+# === DirectoryShrinkRay forwards a per-key log dir ===
+
+
+def test_directory_reducer_uses_per_key_log_dir(tmp_path):
+    initial = {"a.txt": b"KEEP\nremove me\n"}
+
+    async def is_interesting(tc: dict[str, bytes]) -> bool:
+        await trio.lowlevel.checkpoint()
+        return b"KEEP" in tc.get("a.txt", b"")
+
+    problem: BasicReductionProblem[dict[str, bytes]] = BasicReductionProblem(
+        initial=initial,
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+        sort_key=sort_key_for_initial(initial),
+        size=lambda tc: sum(len(v) for v in tc.values()),
+    )
+    reducer = DirectoryShrinkRay(
+        target=problem,
+        python_reducer=False,
+        reducer_log_dir=str(tmp_path / "logs"),
+    )
+    trio.run(reducer.run)
+    # The interesting content survives; the rest is reduced away.
+    assert problem.current_test_case == {"a.txt": b"KEEP"}

--- a/tests/test_generic_language.py
+++ b/tests/test_generic_language.py
@@ -16,6 +16,7 @@ from shrinkray.passes.genericlanguages import (
     reduce_integer_literals,
     regex_pass,
     replace_falsey_with_zero,
+    replace_identifiers_with_zero,
     simplify_brackets,
 )
 from shrinkray.problem import ParseError, shortlex
@@ -196,6 +197,33 @@ def test_replace_falsey_empty_list():
 def test_replace_falsey_empty_parens():
     result = reduce_with([replace_falsey_with_zero], b"()", lambda x: True)
     assert result == b"0"
+
+
+# === replace_identifiers_with_zero tests ===
+
+
+def test_replace_identifier_with_zero():
+    # `x` is an identifier; replacing it with 0 keeps the "assert " prefix.
+    result = reduce_with(
+        [replace_identifiers_with_zero],
+        b"assert x",
+        lambda t: t.startswith(b"assert "),
+    )
+    assert result == b"assert 0"
+
+
+def test_replace_identifier_with_zero_only_touches_names():
+    # A bare integer is not an identifier, so this pass leaves it alone.
+    result = reduce_with([replace_identifiers_with_zero], b"57", lambda t: True)
+    assert result == b"57"
+
+
+def test_replace_identifier_with_zero_rejects_when_uninteresting():
+    # Replacing the only identifier is rejected if it breaks interestingness.
+    result = reduce_with(
+        [replace_identifiers_with_zero], b"keep", lambda t: t == b"keep"
+    )
+    assert result == b"keep"
 
 
 # === simplify_brackets tests ===

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,7 +10,6 @@ import sys
 import time
 from unittest.mock import MagicMock, patch
 
-import black
 import click
 import pexpect
 import pyte
@@ -22,10 +21,6 @@ from click.testing import CliRunner
 from shrinkray.__main__ import _validate_memory_limit, main, worker_main
 from shrinkray.process import default_memory_limit, interrupt_wait_and_kill
 from shrinkray.validation import ValidationResult
-
-
-def format(s: str) -> str:
-    return black.format_str(s, mode=black.Mode()).strip()
 
 
 @pytest.mark.slow
@@ -91,10 +86,10 @@ except AssertionError:
         ]
     )
 
-    # With parallelism > 1, speculative execution races can land the reducer
-    # in different final fixed points (e.g. deleting a.py entirely and
-    # reducing c.py to "assert 0"), so the exact-output assertions below need
-    # a deterministic single-threaded reduction.
+    # Run single-threaded for a deterministic reduction path. (The reduction is
+    # confluent here now that replace_identifiers_with_zero can take `assert x`
+    # to `assert 0`, but --parallelism=1 keeps the exact-output assertions below
+    # robust regardless.)
     if in_place:
         subprocess.check_call(
             [
@@ -123,14 +118,18 @@ except AssertionError:
             ],
         )
 
-    assert a.exists()
+    # c.py reduces all the way to `assert 0`: reduce_integer_literals takes
+    # `x == 2` to `x == 0`, a span deletion drops `x ==`, and (crucially)
+    # replace_identifiers_with_zero turns any surviving `assert x` into
+    # `assert 0`. That drops the cross-file dependency on a.py, so a.py and the
+    # unused b.py are both deleted and only c.py survives.
+    assert not a.exists()
     assert not b.exists()
     assert c.exists()
+    assert c.read_text() == "assert 0"
 
-    # TODO: Remove calls to format when formatting is implemented properly for
-    # directories.
-    assert format(a.read_text()) == "x = 0"
-    assert format(c.read_text()) == "from a import x\n\nassert x"
+    # The reduction preserved interestingness: the script still succeeds.
+    assert subprocess.call([str(script), str(target)]) == 0
 
 
 @pytest.mark.slow

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -14,6 +14,7 @@ from shrinkray.adaptive_timeout import MIN_TIMEOUT, AdaptiveTimeoutPolicy
 from shrinkray.cli import InputType
 from shrinkray.problem import InvalidInitialExample, shortlex
 from shrinkray.process import kill_process_group as original_kill
+from shrinkray.reducer import DirectoryShrinkRay, ShrinkRay
 from shrinkray.state import (
     MemoryLimitExceededOnInitial,
     OutputCaptureManager,
@@ -211,6 +212,103 @@ async def test_single_file_state_run_formatter_command(simple_state):
     result = await simple_state.run_formatter_command(["cat"], b"hello")
     assert result.stdout == b"hello"
     assert result.returncode == 0
+
+
+# === External reducer wiring ===
+
+
+def test_reducer_log_dir_none_without_history(simple_state):
+    # simple_state has history_enabled=False
+    assert simple_state.reducer_log_dir() is None
+
+
+def test_reducer_log_dir_under_history(tmp_path):
+    script = tmp_path / "test.sh"
+    script.write_text("#!/bin/bash\nexit 0")
+    script.chmod(0o755)
+    target = tmp_path / "test.txt"
+    target.write_text("hello world")
+
+    state = ShrinkRayStateSingleFile(
+        input_type=InputType.all,
+        in_place=False,
+        test=[str(script)],
+        filename=str(target),
+        timeout=5.0,
+        base="test.txt",
+        parallelism=1,
+        initial=b"hello world",
+        formatter="none",
+        trivial_is_error=True,
+        seed=0,
+        volume=Volume.quiet,
+        history_enabled=True,
+    )
+    assert state.history_manager is not None
+    log_dir = state.reducer_log_dir()
+    assert log_dir == os.path.join(state.history_manager.history_dir, "reducers")
+
+
+def test_new_reducer_forwards_external_reducer_settings(tmp_path):
+    script = tmp_path / "test.sh"
+    script.write_text("#!/bin/bash\nexit 0")
+    script.chmod(0o755)
+    target = tmp_path / "test.txt"
+    target.write_text("hello world")
+
+    state = ShrinkRayStateSingleFile(
+        input_type=InputType.all,
+        in_place=False,
+        test=[str(script)],
+        filename=str(target),
+        timeout=5.0,
+        base="test.txt",
+        parallelism=1,
+        initial=b"hello world",
+        formatter="none",
+        trivial_is_error=True,
+        seed=0,
+        volume=Volume.quiet,
+        history_enabled=False,
+        external_reducers=[["my-reducer"]],
+        python_reducer=False,
+    )
+    reducer = state.reducer
+    assert isinstance(reducer, ShrinkRay)
+    assert reducer.external_reducers == [["my-reducer"]]
+    assert reducer.python_reducer is False
+    assert reducer.reducer_log_dir is None
+
+
+def test_directory_new_reducer_forwards_settings(tmp_path):
+    script = tmp_path / "test.sh"
+    script.write_text("#!/bin/bash\nexit 0")
+    script.chmod(0o755)
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "a.txt").write_text("hello")
+
+    state = ShrinkRayDirectoryState(
+        input_type=InputType.all,
+        in_place=False,
+        test=[str(script)],
+        filename=str(target),
+        timeout=5.0,
+        base="target",
+        parallelism=1,
+        initial={"a.txt": b"hello"},
+        formatter="none",
+        trivial_is_error=True,
+        seed=0,
+        volume=Volume.quiet,
+        history_enabled=False,
+        external_reducers=[["my-reducer"]],
+        python_reducer=False,
+    )
+    reducer = state.reducer
+    assert isinstance(reducer, DirectoryShrinkRay)
+    assert reducer.external_reducers == [["my-reducer"]]
+    assert reducer.python_reducer is False
 
 
 # === ShrinkRayDirectoryState tests ===

--- a/tests/test_subprocess_worker.py
+++ b/tests/test_subprocess_worker.py
@@ -549,6 +549,7 @@ async def test_worker_start_reduction_reads_external_reducer_params(tmp_path):
         "formatter": "none",
         "volume": "quiet",
         "history_enabled": False,
+        "skip_validation": True,
         "external_reducers": [["my-reducer", "arg"]],
         "python_reducer": False,
     }
@@ -577,6 +578,7 @@ async def test_worker_start_reduction_default_external_reducer_params(tmp_path):
         "formatter": "none",
         "volume": "quiet",
         "history_enabled": False,
+        "skip_validation": True,
     }
 
     await worker._start_reduction(params)

--- a/tests/test_subprocess_worker.py
+++ b/tests/test_subprocess_worker.py
@@ -532,6 +532,60 @@ async def test_worker_start_reduction_single_file(tmp_path):
     assert worker.problem.current_test_case == b"hello world"
 
 
+async def test_worker_start_reduction_reads_external_reducer_params(tmp_path):
+    """_start_reduction forwards external_reducers/python_reducer to the state."""
+    target = tmp_path / "test.txt"
+    target.write_text("hello world")
+    script = tmp_path / "test.sh"
+    script.write_text("#!/bin/bash\nexit 0")
+    script.chmod(0o755)
+
+    worker = ReducerWorker(output_stream=MemoryOutputStream())
+    params = {
+        "file_path": str(target),
+        "test": [str(script)],
+        "parallelism": 1,
+        "timeout": 1.0,
+        "formatter": "none",
+        "volume": "quiet",
+        "history_enabled": False,
+        "external_reducers": [["my-reducer", "arg"]],
+        "python_reducer": False,
+    }
+
+    await worker._start_reduction(params)
+
+    assert worker.state is not None
+    assert worker.state.external_reducers == [["my-reducer", "arg"]]
+    assert worker.state.python_reducer is False
+
+
+async def test_worker_start_reduction_default_external_reducer_params(tmp_path):
+    """_start_reduction defaults external reducers off / python reducer on."""
+    target = tmp_path / "test.txt"
+    target.write_text("hello world")
+    script = tmp_path / "test.sh"
+    script.write_text("#!/bin/bash\nexit 0")
+    script.chmod(0o755)
+
+    worker = ReducerWorker(output_stream=MemoryOutputStream())
+    params = {
+        "file_path": str(target),
+        "test": [str(script)],
+        "parallelism": 1,
+        "timeout": 1.0,
+        "formatter": "none",
+        "volume": "quiet",
+        "history_enabled": False,
+    }
+
+    await worker._start_reduction(params)
+
+    assert worker.state is not None
+    assert worker.state.external_reducers == []
+    assert worker.state.python_reducer is True
+
+
 async def test_worker_start_reduction_skip_validation(tmp_path):
     """Test _start_reduction with skip_validation=True skips setup()."""
     # Create a test file

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -96,6 +96,8 @@ class FakeReductionClient:
         skip_validation: bool = False,
         history_enabled: bool = True,
         also_interesting_code: int | None = None,
+        external_reducers: list[list[str]] | None = None,
+        python_reducer: bool = True,
     ) -> Response:
         if self._start_error:
             return Response(id="start", error=self._start_error)
@@ -3016,6 +3018,8 @@ def test_run_textual_ui_creates_and_runs_app():
             theme="dark",
             history_enabled=True,
             also_interesting_code=None,
+            external_reducers=None,
+            python_reducer=True,
         )
 
         # Verify run() was called

--- a/tests/test_tui_snapshots.py
+++ b/tests/test_tui_snapshots.py
@@ -58,6 +58,8 @@ class FakeReductionClientForSnapshots:
         skip_validation: bool = False,
         history_enabled: bool = True,
         also_interesting_code: int | None = None,
+        external_reducers: list[list[str]] | None = None,
+        python_reducer: bool = True,
     ) -> Response:
         return Response(id="start", result={"status": "started"})
 


### PR DESCRIPTION
This adds an external reducer feature, which allows users to provide an external program that shrinkray will use to generate novel reduction candidates. It also moves the Python reducer over to this mechanism (partly to try it out, partly because libcst is demonstrably easy to crash)

<details>
<summary>Full description (AI-generated)</summary>

**External reducer mechanism.** An external reducer is a subprocess that reduces a test case by exchanging newline-delimited JSON with Shrink Ray: Shrink Ray sends a `reduce` request with the current test case, the reducer emits candidate `content` queries, Shrink Ray answers each with the interestingness result (up to `--parallelism` at a time), and the reducer reports `idle` when it reaches a fixpoint. It stays alive for the next request, so libcst loads once; a reducer that instead exits at a fixpoint is also supported and gets relaunched. `notes/external-reducers.md` documents the protocol.

**Python reducer migration.** The existing libcst passes now run unchanged inside `python -m shrinkray.reducers.python` against a reduction problem whose interestingness test is answered over the protocol, preserving the parallel search. Enabled automatically for Python-looking input; `--no-python-reducer` disables it.

**CLI.** `--reduce-with '<command>'` is repeatable and runs each command as a reduction pass. Logs go to `.shrinkray/<run>/reducers/` when history is enabled.

**`replace_identifiers_with_zero`.** A generic pass (like `replace_falsey_with_zero`) that tries replacing each identifier with `0`. In the directory test this makes the reduction confluent — previously `assert x` was a dead end, so concurrent directory reduction non-deterministically ended at either `assert x` (keeping `a.py`) or `assert 0` (deleting it); now both converge on `assert 0`.

Interaction to be aware of: because the reducer is a subprocess, its timing can expose latent non-confluence in *concurrent directory reduction* for other inputs too (single-file reduction stays deterministic).
</details>