### PR TITLE
Grammar-guided LLM transformation pumps via tree-sitter

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+- When the LLM is enabled and the input's language has a tree-sitter grammar,
+  Shrink Ray now also uses the model to inline function calls: the grammar
+  finds calls to functions defined in the file, and the model rewrites just
+  that call, leaving the rest of the file untouched. Inlining a call often
+  lets the function definition be deleted afterwards, unlocking reductions
+  that were previously only found for C and C++.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,9 @@
 - When the LLM is enabled and the input's language has a tree-sitter grammar,
-  Shrink Ray now also uses the model to inline function calls: the grammar
-  finds calls to functions defined in the file, and the model rewrites just
-  that call, leaving the rest of the file untouched. Inlining a call often
-  lets the function definition be deleted afterwards, unlocking reductions
-  that were previously only found for C and C++.
+  Shrink Ray now also uses the model for targeted transformations: the grammar
+  finds the site (a call to a function defined in the file, a use of a
+  variable/type alias/macro, a function body, a loop, a constant expression)
+  and the model rewrites just that site — inlining the call or definition,
+  stubbing the body, unrolling the loop's first iteration, or folding the
+  constant — leaving the rest of the file untouched. These unlock reductions
+  (like deleting a function once its calls are inlined) that were previously
+  only found for C and C++.

--- a/evaluation/llm_inline_experiment.py
+++ b/evaluation/llm_inline_experiment.py
@@ -1,19 +1,21 @@
 #!/usr/bin/env python3
-"""Measure the grammar-guided LLM inlining pump against a real model.
+"""Measure the grammar-guided LLM transformation pumps against a real model.
 
-Each problem is a small program with a function whose definition cannot
-be deleted while a call to it remains, judged by a real semantic oracle
-(run the program, require exact output). Classical passes can shrink
-names and whitespace but cannot rewrite the call into its inlined form,
-so the function definition survives; the inlining pump should remove it.
+Each problem is a small program with a construct classical passes cannot
+remove — a call whose function definition must otherwise stay, a
+once-bound name, a loop, a body that cannot legally be emptied — judged
+by a real semantic oracle (run the program, require exact output). The
+grammar-guided pumps should rewrite the construct so the scaffolding it
+kept alive becomes deletable.
 
 Runs each problem in three modes and reports final sizes side by side:
 
 - classical: the ordinary passes only (no LLM at all).
 - rewrite: the ordinary passes plus the whole-file llm_rewrite pass,
   with the pumps disabled.
-- pump: the ordinary passes plus llm_inline_calls, with the whole-file
-  llm_rewrite pass stripped out so the pump's contribution is isolated.
+- pump: the ordinary passes plus all five grammar-guided transformation
+  pumps, with the whole-file llm_rewrite pass stripped out so the
+  pumps' contribution is isolated.
 
 restart_at_fixpoint is disabled in every mode: the restarted
 sub-reduction builds its own pass list, which would let llm_rewrite
@@ -65,10 +67,6 @@ class InlineProblem:
     extension: str
     initial: bytes
     expected_output: str
-    # The function the problem wants inlined away. Success is judged by
-    # eye from the final test case: passes rename identifiers, so the
-    # name itself cannot be checked for.
-    function_name: bytes
     # argv to run a source file, with {file} (and for C {binary})
     # placeholders. A two-step compile-and-run is expressed by compile_argv.
     run_argv: list[str]
@@ -110,7 +108,6 @@ PROBLEMS: dict[str, InlineProblem] = {
         extension=".py",
         initial=(b"N = 3\n\ndef f(x):\n    return x + N\n\nprint(f(N))\n"),
         expected_output="6\n",
-        function_name=b"N",
         run_argv=["python3", "{file}"],
         oracle_description='Running the file must print exactly "6".',
     ),
@@ -121,7 +118,6 @@ PROBLEMS: dict[str, InlineProblem] = {
         extension=".py",
         initial=(b"total = 0\nfor i in [5]:\n    total += i\nprint(total)\n"),
         expected_output="5\n",
-        function_name=b"total",
         run_argv=["python3", "{file}"],
         oracle_description='Running the file must print exactly "5".',
     ),
@@ -147,7 +143,6 @@ PROBLEMS: dict[str, InlineProblem] = {
             b"}\n"
         ),
         expected_output="ok\n",
-        function_name=b"big",
         run_argv=["go", "run", "{file}"],
         required_line=b"big(1)",
         oracle_description=(
@@ -160,7 +155,6 @@ PROBLEMS: dict[str, InlineProblem] = {
         extension=".py",
         initial=(b"def add_one(x):\n    return x + 1\n\nprint(add_one(3))\n"),
         expected_output="4\n",
-        function_name=b"add_one",
         run_argv=["python3", "{file}"],
         oracle_description='Running the file must print exactly "4".',
     ),
@@ -178,7 +172,6 @@ PROBLEMS: dict[str, InlineProblem] = {
             b"print(scale(10))\n"
         ),
         expected_output="21\n",
-        function_name=b"scale",
         run_argv=["python3", "{file}"],
         oracle_description='Running the file must print exactly "21".',
     ),
@@ -187,7 +180,6 @@ PROBLEMS: dict[str, InlineProblem] = {
         extension=".js",
         initial=(b"function addOne(x) { return x + 1; }\nconsole.log(addOne(3));\n"),
         expected_output="4\n",
-        function_name=b"addOne",
         run_argv=["node", "{file}"],
         oracle_description='Running the file must print exactly "4".',
     ),
@@ -196,7 +188,6 @@ PROBLEMS: dict[str, InlineProblem] = {
         extension=".rb",
         initial=(b"def add_one(x)\n  x + 1\nend\nputs add_one(3)\n"),
         expected_output="4\n",
-        function_name=b"add_one",
         run_argv=["ruby", "{file}"],
         oracle_description='Running the file must print exactly "4".',
     ),
@@ -209,7 +200,6 @@ PROBLEMS: dict[str, InlineProblem] = {
             b'int main(void) { printf("%d\\n", add_one(3)); return 0; }\n'
         ),
         expected_output="4\n",
-        function_name=b"add_one",
         run_argv=["{binary}"],
         compile_argv=["cc", "-x", "c", "{file}", "-o", "{binary}"],
         oracle_description='Running the file must print exactly "4".',
@@ -219,7 +209,6 @@ PROBLEMS: dict[str, InlineProblem] = {
         extension=".py",
         initial=_python_large(),
         expected_output="22\n",
-        function_name=b"combine",
         run_argv=["python3", "{file}"],
         required_line=b"self.value = 7",
         oracle_description=(
@@ -335,12 +324,15 @@ async def reduce_problem(
     reducer = reducer_class(
         target=reduction_problem,
         treesitter_language=problem.language,
+        # A real run on C/C++ input gets the hand-written passes and
+        # inliner pumps; the baseline is dishonest without them.
+        enable_cpp_passes=problem.language in ("c", "cpp"),
         python_reducer=False,
         restart_at_fixpoint=False,
         **kwargs,
     )
     if mode == "pump":
-        # Isolate the inlining pump: drop the whole-file rewrite pass.
+        # Isolate the pumps: drop the whole-file rewrite pass.
         reducer.last_ditch_passes = [
             p for p in reducer.last_ditch_passes if p.__name__ != "llm_rewrite"
         ]
@@ -376,6 +368,9 @@ async def main() -> None:
     parser.add_argument("--modes", default="classical,rewrite,pump")
     args = parser.parse_args()
     names = args.problems or list(PROBLEMS)
+    unknown = [name for name in names if name not in PROBLEMS]
+    if unknown:
+        parser.error(f"Unknown problems: {', '.join(unknown)}")
     modes = args.modes.split(",")
 
     client = None
@@ -401,7 +396,11 @@ async def main() -> None:
                 flush=True,
             )
             print("  final: " + result["final"].replace("\n", "\\n"), flush=True)
-    (RESULTS_DIR / "results.json").write_text(json.dumps(all_results, indent=2))
+            # Rewritten after every mode: a full run takes hours, and a
+            # crash or interrupt must not lose the completed results.
+            (RESULTS_DIR / "results.json").write_text(
+                json.dumps(all_results, indent=2)
+            )
     print(f"\nFull results in {RESULTS_DIR}")
 
 

--- a/evaluation/llm_inline_experiment.py
+++ b/evaluation/llm_inline_experiment.py
@@ -102,6 +102,59 @@ def _python_large() -> bytes:
 
 
 PROBLEMS: dict[str, InlineProblem] = {
+    # Exercises llm_inline_definitions (and then llm_inline_calls and
+    # llm_evaluate_constants): N is bound once and used twice, and its
+    # binding cannot be deleted while the uses remain.
+    "python_globals": InlineProblem(
+        language="python",
+        extension=".py",
+        initial=(b"N = 3\n\ndef f(x):\n    return x + N\n\nprint(f(N))\n"),
+        expected_output="6\n",
+        function_name=b"N",
+        run_argv=["python3", "{file}"],
+        oracle_description='Running the file must print exactly "6".',
+    ),
+    # Exercises llm_unroll_loops: the loop cannot be deleted while the
+    # accumulation is needed, and no mechanical pass can unroll it.
+    "python_loop": InlineProblem(
+        language="python",
+        extension=".py",
+        initial=(b"total = 0\nfor i in [5]:\n    total += i\nprint(total)\n"),
+        expected_output="5\n",
+        function_name=b"total",
+        run_argv=["python3", "{file}"],
+        oracle_description='Running the file must print exactly "5".',
+    ),
+    # Exercises llm_stub_bodies: the oracle pins the call text, so the
+    # definition must stay, and Go rejects an empty body for a function
+    # returning int — only a synthesized stub can shrink it.
+    "go_stub": InlineProblem(
+        language="go",
+        extension=".go",
+        initial=(
+            b"package main\n\n"
+            b"import \"fmt\"\n\n"
+            b"func big(x int) int {\n"
+            b"\ty := x * 2\n"
+            b"\tfor i := 0; i < 3; i++ {\n"
+            b"\t\ty += i\n"
+            b"\t}\n"
+            b"\treturn y\n"
+            b"}\n\n"
+            b"func main() {\n"
+            b"\tbig(1)\n"
+            b'\tfmt.Println("ok")\n'
+            b"}\n"
+        ),
+        expected_output="ok\n",
+        function_name=b"big",
+        run_argv=["go", "run", "{file}"],
+        required_line=b"big(1)",
+        oracle_description=(
+            'Running the file must print exactly "ok", and the file must '
+            'still contain "big(1)".'
+        ),
+    ),
     "python_simple": InlineProblem(
         language="python",
         extension=".py",

--- a/evaluation/llm_inline_experiment.py
+++ b/evaluation/llm_inline_experiment.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Measure the grammar-guided LLM inlining pump against a real model.
+
+Each problem is a small program with a function whose definition cannot
+be deleted while a call to it remains, judged by a real semantic oracle
+(run the program, require exact output). Classical passes can shrink
+names and whitespace but cannot rewrite the call into its inlined form,
+so the function definition survives; the inlining pump should remove it.
+
+Runs each problem in three modes and reports final sizes side by side:
+
+- classical: the ordinary passes only (no LLM at all).
+- rewrite: the ordinary passes plus the whole-file llm_rewrite pass,
+  with the pumps disabled.
+- pump: the ordinary passes plus llm_inline_calls, with the whole-file
+  llm_rewrite pass stripped out so the pump's contribution is isolated.
+
+restart_at_fixpoint is disabled in every mode: the restarted
+sub-reduction builds its own pass list, which would let llm_rewrite
+leak into pump mode and muddy the attribution.
+
+Model prompts and responses, and each mode's final test case, are
+written to work/llm_inline_experiment/.
+
+Needs the model (downloaded on first use) and the python3/node/ruby/cc
+binaries for the oracles.
+
+    uv run python evaluation/llm_inline_experiment.py             # all problems
+    uv run python evaluation/llm_inline_experiment.py python_simple
+    uv run python evaluation/llm_inline_experiment.py --modes pump
+"""
+
+import argparse
+import json
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import trio
+from attrs import define, field
+
+from shrinkray.llm_client import LlamaCppClient
+from shrinkray.passes.llm import (
+    DEFAULT_MODEL_SPEC,
+    LLMClient,
+    LLMConfig,
+    parse_model_spec,
+)
+from shrinkray.problem import BasicReductionProblem
+from shrinkray.reducer import ShrinkRay
+from shrinkray.state import sort_key_for_initial
+from shrinkray.work import Volume, WorkContext
+
+
+EVAL_DIR = Path(__file__).resolve().parent
+RESULTS_DIR = EVAL_DIR / "work" / "llm_inline_experiment"
+PER_MODE_TIMEOUT = 600.0
+ORACLE_TIMEOUT = 10.0
+
+
+@define
+class InlineProblem:
+    language: str
+    extension: str
+    initial: bytes
+    expected_output: str
+    # The function the problem wants inlined away. Success is judged by
+    # eye from the final test case: passes rename identifiers, so the
+    # name itself cannot be checked for.
+    function_name: bytes
+    # argv to run a source file, with {file} (and for C {binary})
+    # placeholders. A two-step compile-and-run is expressed by compile_argv.
+    run_argv: list[str]
+    compile_argv: list[str] | None = None
+    # A line the oracle requires verbatim in the candidate, mimicking a
+    # bug that needs a specific construct. Whole-file rewrites tend to
+    # drop it; targeted splicing leaves it untouched.
+    required_line: bytes | None = None
+    # Natural-language description of the oracle, shown to llm_rewrite
+    # the way a real run shows the user's test script.
+    oracle_description: str | None = None
+
+
+def _python_large() -> bytes:
+    """A bigger file: one function to inline, plus deletable filler and
+    a class the oracle (silently) requires kept intact."""
+    lines = [
+        "class Config:",
+        "    def __init__(self):",
+        "        self.value = 7",
+        "        self.scale = 3",
+        "",
+        "def combine(a, b):",
+        "    return a * b + 1",
+        "",
+    ]
+    for i in range(15):
+        lines += [f"def helper_{i}(x):", f"    return x + {i}", ""]
+    lines += ["cfg = Config()", "print(combine(cfg.value, cfg.scale))", ""]
+    return "\n".join(lines).encode()
+
+
+PROBLEMS: dict[str, InlineProblem] = {
+    "python_simple": InlineProblem(
+        language="python",
+        extension=".py",
+        initial=(b"def add_one(x):\n    return x + 1\n\nprint(add_one(3))\n"),
+        expected_output="4\n",
+        function_name=b"add_one",
+        run_argv=["python3", "{file}"],
+        oracle_description='Running the file must print exactly "4".',
+    ),
+    # A multi-statement body: the hand-written C++ inliner refuses
+    # these, so this is territory only the model can reach.
+    "python_multi": InlineProblem(
+        language="python",
+        extension=".py",
+        initial=(
+            b"def scale(x):\n"
+            b"    y = x * 2\n"
+            b"    y = y + 1\n"
+            b"    return y\n"
+            b"\n"
+            b"print(scale(10))\n"
+        ),
+        expected_output="21\n",
+        function_name=b"scale",
+        run_argv=["python3", "{file}"],
+        oracle_description='Running the file must print exactly "21".',
+    ),
+    "javascript_simple": InlineProblem(
+        language="javascript",
+        extension=".js",
+        initial=(b"function addOne(x) { return x + 1; }\nconsole.log(addOne(3));\n"),
+        expected_output="4\n",
+        function_name=b"addOne",
+        run_argv=["node", "{file}"],
+        oracle_description='Running the file must print exactly "4".',
+    ),
+    "ruby_simple": InlineProblem(
+        language="ruby",
+        extension=".rb",
+        initial=(b"def add_one(x)\n  x + 1\nend\nputs add_one(3)\n"),
+        expected_output="4\n",
+        function_name=b"add_one",
+        run_argv=["ruby", "{file}"],
+        oracle_description='Running the file must print exactly "4".',
+    ),
+    "c_simple": InlineProblem(
+        language="c",
+        extension=".c",
+        initial=(
+            b"#include <stdio.h>\n"
+            b"static int add_one(int x) { return x + 1; }\n"
+            b'int main(void) { printf("%d\\n", add_one(3)); return 0; }\n'
+        ),
+        expected_output="4\n",
+        function_name=b"add_one",
+        run_argv=["{binary}"],
+        compile_argv=["cc", "-x", "c", "{file}", "-o", "{binary}"],
+        oracle_description='Running the file must print exactly "4".',
+    ),
+    "python_large": InlineProblem(
+        language="python",
+        extension=".py",
+        initial=_python_large(),
+        expected_output="22\n",
+        function_name=b"combine",
+        run_argv=["python3", "{file}"],
+        required_line=b"self.value = 7",
+        oracle_description=(
+            'Running the file must print exactly "22", and the file must '
+            'still contain the line "self.value = 7".'
+        ),
+    ),
+}
+
+
+@define
+class LoggingClient(LLMClient):
+    """Wraps a client, recording every prompt/response exchange."""
+
+    inner: LLMClient
+    exchanges: list[dict[str, str]] = field(factory=list)
+
+    async def complete(
+        self, prompt: str, *, max_tokens: int, seed: int, temperature: float
+    ) -> str:
+        start = time.monotonic()
+        response = await self.inner.complete(
+            prompt, max_tokens=max_tokens, seed=seed, temperature=temperature
+        )
+        self.exchanges.append(
+            {
+                "prompt": prompt,
+                "response": response,
+                "seconds": round(time.monotonic() - start, 1),
+            }
+        )
+        return response
+
+    def start_loading(self) -> None:
+        self.inner.start_loading()
+
+    async def wait_until_ready(self) -> None:
+        await self.inner.wait_until_ready()
+
+    def is_disabled(self) -> bool:
+        return self.inner.is_disabled()
+
+
+class NoPumpShrinkRay(ShrinkRay):
+    """ShrinkRay with pumps disabled, isolating the whole-file rewrite."""
+
+    @property
+    def pumps(self):
+        return ()
+
+
+def make_oracle(problem: InlineProblem):
+    """An async interestingness test running the candidate for real."""
+
+    async def is_interesting(candidate: bytes) -> bool:
+        if problem.required_line is not None and problem.required_line not in candidate:
+            return False
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / f"candidate{problem.extension}"
+            source.write_bytes(candidate)
+            binary = Path(tmp) / "candidate.bin"
+            substitutions = {"{file}": str(source), "{binary}": str(binary)}
+
+            async def run(argv: list[str]) -> subprocess.CompletedProcess | None:
+                argv = [substitutions.get(a, a) for a in argv]
+                with trio.move_on_after(ORACLE_TIMEOUT):
+                    return await trio.run_process(
+                        argv,
+                        capture_stdout=True,
+                        capture_stderr=True,
+                        check=False,
+                    )
+                return None
+
+            if problem.compile_argv is not None:
+                compiled = await run(problem.compile_argv)
+                if compiled is None or compiled.returncode != 0:
+                    return False
+            result = await run(problem.run_argv)
+            if result is None or result.returncode != 0:
+                return False
+            return result.stdout.decode("utf-8", errors="replace") == (
+                problem.expected_output
+            )
+
+    return is_interesting
+
+
+async def reduce_problem(
+    name: str, problem: InlineProblem, mode: str, client: LlamaCppClient | None
+) -> dict:
+    logging_client = None
+    reduction_problem: BasicReductionProblem[bytes] = BasicReductionProblem(
+        initial=problem.initial,
+        is_interesting=make_oracle(problem),
+        work=WorkContext(parallelism=2, volume=Volume.quiet),
+        sort_key=sort_key_for_initial(problem.initial),
+    )
+    kwargs = {}
+    reducer_class = ShrinkRay
+    if mode in ("rewrite", "pump"):
+        assert client is not None
+        logging_client = LoggingClient(inner=client)
+        kwargs = {
+            "llm_client": logging_client,
+            "llm_config": LLMConfig(
+                filename=f"candidate{problem.extension}",
+                oracle=problem.oracle_description,
+            ),
+        }
+        if mode == "rewrite":
+            reducer_class = NoPumpShrinkRay
+    reducer = reducer_class(
+        target=reduction_problem,
+        treesitter_language=problem.language,
+        python_reducer=False,
+        restart_at_fixpoint=False,
+        **kwargs,
+    )
+    if mode == "pump":
+        # Isolate the inlining pump: drop the whole-file rewrite pass.
+        reducer.last_ditch_passes = [
+            p for p in reducer.last_ditch_passes if p.__name__ != "llm_rewrite"
+        ]
+    start = time.monotonic()
+    with trio.move_on_after(PER_MODE_TIMEOUT) as scope:
+        await reducer.run()
+    elapsed = time.monotonic() - start
+
+    final = reduction_problem.current_test_case
+    out_dir = RESULTS_DIR / name
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / f"{mode}-final{problem.extension}").write_bytes(final)
+    exchanges = logging_client.exchanges if logging_client is not None else []
+    if exchanges:
+        (out_dir / f"{mode}-exchanges.json").write_text(
+            json.dumps(exchanges, indent=2)
+        )
+    return {
+        "mode": mode,
+        "initial_size": len(problem.initial),
+        "final_size": len(final),
+        "final": final.decode("utf-8", errors="replace"),
+        "calls": reduction_problem.stats.calls,
+        "model_calls": len(exchanges),
+        "seconds": round(elapsed, 1),
+        "timed_out": scope.cancelled_caught,
+    }
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("problems", nargs="*", default=None)
+    parser.add_argument("--modes", default="classical,rewrite,pump")
+    args = parser.parse_args()
+    names = args.problems or list(PROBLEMS)
+    modes = args.modes.split(",")
+
+    client = None
+    if "pump" in modes or "rewrite" in modes:
+        client = LlamaCppClient(model=parse_model_spec(DEFAULT_MODEL_SPEC))
+        client.start_loading()
+
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    all_results: dict[str, list[dict]] = {}
+    for name in names:
+        problem = PROBLEMS[name]
+        all_results[name] = []
+        for mode in modes:
+            print(f"=== {name} [{mode}] ===", flush=True)
+            result = await reduce_problem(name, problem, mode, client)
+            all_results[name].append(result)
+            print(
+                f"  {result['initial_size']}B -> {result['final_size']}B "
+                f"in {result['seconds']}s "
+                f"({result['calls']} oracle calls, "
+                f"{result['model_calls']} model calls"
+                f"{', TIMED OUT' if result['timed_out'] else ''})",
+                flush=True,
+            )
+            print("  final: " + result["final"].replace("\n", "\\n"), flush=True)
+    (RESULTS_DIR / "results.json").write_text(json.dumps(all_results, indent=2))
+    print(f"\nFull results in {RESULTS_DIR}")
+
+
+if __name__ == "__main__":
+    trio.run(main)

--- a/notes/import-graph.dot
+++ b/notes/import-graph.dot
@@ -17,6 +17,7 @@ digraph imports {
     "passes.genericlanguages";
     "passes.json";
     "passes.llm";
+    "passes.llmtransforms";
     "passes.patching";
     "passes.python";
     "passes.sat";
@@ -64,6 +65,10 @@ digraph imports {
     "passes.json" -> "problem";
     "passes.llm" -> "passes.definitions";
     "passes.llm" -> "problem";
+    "passes.llmtransforms" -> "passes.definitions";
+    "passes.llmtransforms" -> "passes.llm";
+    "passes.llmtransforms" -> "passes.treesitter";
+    "passes.llmtransforms" -> "problem";
     "passes.patching" -> "problem";
     "passes.python" -> "problem";
     "passes.python" -> "work";
@@ -89,6 +94,7 @@ digraph imports {
     "reducer" -> "passes.genericlanguages";
     "reducer" -> "passes.json";
     "reducer" -> "passes.llm";
+    "reducer" -> "passes.llmtransforms";
     "reducer" -> "passes.patching";
     "reducer" -> "passes.python";
     "reducer" -> "passes.sat";

--- a/notes/import-graph.md
+++ b/notes/import-graph.md
@@ -21,120 +21,126 @@ flowchart TD
     n12[passes.genericlanguages]
     n13[passes.json]
     n14[passes.llm]
-    n15[passes.patching]
-    n16[passes.python]
-    n17[passes.sat]
-    n18[passes.sequences]
-    n19[passes.treesitter]
-    n20[problem]
-    n21[process]
-    n22[reducer]
-    n23[reducers]
-    n24[reducers.driver]
-    n25[reducers.protocol]
-    n26[reducers.python]
-    n27[reformat]
-    n28[state]
-    n29[subprocess]
-    n30[subprocess.client]
-    n31[subprocess.protocol]
-    n32[subprocess.worker]
-    n33[tui]
-    n34[ui]
-    n35[validation]
-    n36[work]
+    n15[passes.llmtransforms]
+    n16[passes.patching]
+    n17[passes.python]
+    n18[passes.sat]
+    n19[passes.sequences]
+    n20[passes.treesitter]
+    n21[problem]
+    n22[process]
+    n23[reducer]
+    n24[reducers]
+    n25[reducers.driver]
+    n26[reducers.protocol]
+    n27[reducers.python]
+    n28[reformat]
+    n29[state]
+    n30[subprocess]
+    n31[subprocess.client]
+    n32[subprocess.protocol]
+    n33[subprocess.worker]
+    n34[tui]
+    n35[ui]
+    n36[validation]
+    n37[work]
 
     n3 --> n6
-    n3 --> n19
-    n4 --> n27
+    n3 --> n20
+    n4 --> n28
     n5 --> n2
     n6 --> n14
-    n8 --> n15
-    n8 --> n20
+    n8 --> n16
+    n8 --> n21
     n9 --> n10
-    n9 --> n15
-    n9 --> n20
-    n10 --> n20
-    n11 --> n20
+    n9 --> n16
+    n9 --> n21
+    n10 --> n21
     n11 --> n21
-    n11 --> n25
+    n11 --> n22
+    n11 --> n26
     n12 --> n8
     n12 --> n10
-    n12 --> n15
-    n12 --> n20
-    n12 --> n36
+    n12 --> n16
+    n12 --> n21
+    n12 --> n37
     n13 --> n10
-    n13 --> n15
-    n13 --> n20
+    n13 --> n16
+    n13 --> n21
     n14 --> n10
-    n14 --> n20
+    n14 --> n21
+    n15 --> n10
+    n15 --> n14
     n15 --> n20
-    n16 --> n20
-    n16 --> n36
-    n17 --> n10
-    n17 --> n15
-    n17 --> n18
-    n17 --> n20
+    n15 --> n21
+    n16 --> n21
+    n17 --> n21
+    n17 --> n37
     n18 --> n10
-    n18 --> n15
-    n18 --> n20
+    n18 --> n16
+    n18 --> n19
+    n18 --> n21
     n19 --> n10
-    n19 --> n15
-    n19 --> n20
-    n20 --> n4
-    n20 --> n27
-    n20 --> n36
-    n22 --> n3
-    n22 --> n5
-    n22 --> n8
-    n22 --> n9
-    n22 --> n10
-    n22 --> n11
-    n22 --> n12
-    n22 --> n13
-    n22 --> n14
-    n22 --> n15
-    n22 --> n16
-    n22 --> n17
-    n22 --> n18
-    n22 --> n19
-    n22 --> n20
-    n22 --> n36
-    n24 --> n10
-    n24 --> n20
-    n24 --> n25
-    n24 --> n36
-    n26 --> n16
-    n26 --> n24
-    n28 --> n1
-    n28 --> n2
-    n28 --> n3
-    n28 --> n4
-    n28 --> n5
-    n28 --> n6
-    n28 --> n9
-    n28 --> n14
-    n28 --> n20
-    n28 --> n21
-    n28 --> n22
-    n28 --> n36
-    n29 --> n30
-    n29 --> n31
-    n30 --> n14
+    n19 --> n16
+    n19 --> n21
+    n20 --> n10
+    n20 --> n16
+    n20 --> n21
+    n21 --> n4
+    n21 --> n28
+    n21 --> n37
+    n23 --> n3
+    n23 --> n5
+    n23 --> n8
+    n23 --> n9
+    n23 --> n10
+    n23 --> n11
+    n23 --> n12
+    n23 --> n13
+    n23 --> n14
+    n23 --> n15
+    n23 --> n16
+    n23 --> n17
+    n23 --> n18
+    n23 --> n19
+    n23 --> n20
+    n23 --> n21
+    n23 --> n37
+    n25 --> n10
+    n25 --> n21
+    n25 --> n26
+    n25 --> n37
+    n27 --> n17
+    n27 --> n25
+    n29 --> n1
+    n29 --> n2
+    n29 --> n3
+    n29 --> n4
+    n29 --> n5
+    n29 --> n6
+    n29 --> n9
+    n29 --> n14
+    n29 --> n21
+    n29 --> n22
+    n29 --> n23
+    n29 --> n37
     n30 --> n31
-    n32 --> n2
-    n32 --> n14
-    n32 --> n20
-    n32 --> n28
-    n32 --> n31
-    n32 --> n36
-    n33 --> n4
+    n30 --> n32
+    n31 --> n14
+    n31 --> n32
+    n33 --> n2
     n33 --> n14
-    n33 --> n30
-    n33 --> n31
-    n34 --> n20
-    n34 --> n28
-    n35 --> n2
+    n33 --> n21
+    n33 --> n29
+    n33 --> n32
+    n33 --> n37
+    n34 --> n4
+    n34 --> n14
+    n34 --> n31
+    n34 --> n32
+    n35 --> n21
+    n35 --> n29
+    n36 --> n2
 ```
 
 ---

--- a/src/shrinkray/passes/llmtransforms.py
+++ b/src/shrinkray/passes/llmtransforms.py
@@ -546,10 +546,10 @@ def llm_transform_pump(
 ) -> ReductionPump[bytes]:
     """A pump applying one grammar-guided transformation with the model.
 
-    Each round parses the current result, finds the transformation's
-    targets, and asks the model to rewrite one span at a time; whenever
-    a spliced candidate is interesting it is adopted and the targets
-    are rederived (adoption shifts every later span). Responses are
+    Each round asks the model to rewrite one target span at a time;
+    whenever a spliced candidate is interesting it is adopted and the
+    targets are rederived by reparsing (adoption shifts every later
+    span; fruitless rounds reuse the same targets). Responses are
     remembered per prompt: rederived targets replay earlier answers
     before asking again, and a prompt whose answers all failed is
     retried with a fresh seed up to max_prompt_attempts times, since a

--- a/src/shrinkray/passes/llmtransforms.py
+++ b/src/shrinkray/passes/llmtransforms.py
@@ -556,17 +556,26 @@ def llm_transform_pump(
         completions = 0
         adoptions = 0
 
-        async def try_response(response: str, span: tuple[int, int]) -> bool:
+        async def try_response(response: str, target: TransformTarget) -> bool:
             nonlocal current, adoptions
-            for replacement in extract_candidates(response):
-                candidate = splice(current, span, replacement.strip())
-                if candidate in seen:
-                    continue
-                seen.add(candidate)
-                if await problem.is_interesting(candidate):
-                    current = candidate
-                    adoptions += 1
-                    return True
+            context = target.context.encode()
+            for block in extract_candidates(response):
+                replacements = [block.strip()]
+                # Small models often echo the reference context (e.g. a
+                # function signature) ahead of the actual replacement;
+                # salvage those answers by also trying the suffix, and
+                # try it first since it is strictly smaller.
+                if context and replacements[0].startswith(context):
+                    replacements.insert(0, replacements[0][len(context) :].strip())
+                for replacement in replacements:
+                    candidate = splice(current, target.span, replacement)
+                    if candidate in seen:
+                        continue
+                    seen.add(candidate)
+                    if await problem.is_interesting(candidate):
+                        current = candidate
+                        adoptions += 1
+                        return True
             return False
 
         while adoptions < max_adoptions:
@@ -578,7 +587,7 @@ def llm_transform_pump(
                 # Adoption shifts spans, so a previously useless answer
                 # can produce a fresh candidate on the new state.
                 for response in cached:
-                    if await try_response(response, target.span):
+                    if await try_response(response, target):
                         improved = True
                         break
                 if improved:
@@ -604,7 +613,7 @@ def llm_transform_pump(
                     temperature=config.temperature,
                 )
                 cached.append(response)
-                if await try_response(response, target.span):
+                if await try_response(response, target):
                     improved = True
                     break
             if not improved and not asked:

--- a/src/shrinkray/passes/llmtransforms.py
+++ b/src/shrinkray/passes/llmtransforms.py
@@ -278,11 +278,18 @@ def inline_call_targets(
 
 
 def _binding_parts(
-    node: tree_sitter.Node,
+    node: tree_sitter.Node, source: bytes
 ) -> tuple[tree_sitter.Node, tree_sitter.Node] | None:
     """The (name, definition) children of a node binding one plain
     identifier to a value or type, or None."""
     if not _matches(node.type, _BINDING_WORDS):
+        return None
+    # An augmented assignment (`x += 1`) reads the name's prior value
+    # rather than defining it. Every grammar exposes the compound
+    # operator through an `operator` field; plain bindings either have
+    # no such field or a bare `=`.
+    operator = node.child_by_field_name("operator")
+    if operator is not None and source[operator.start_byte : operator.end_byte] != b"=":
         return None
     value = node.child_by_field_name("value")
     if value is None:
@@ -319,7 +326,7 @@ def inline_definition_targets(
     for node in iter_nodes(tree):
         if not node.is_named:
             continue
-        parts = _binding_parts(node)
+        parts = _binding_parts(node, source)
         if parts is None:
             continue
         name_node = parts[0]

--- a/src/shrinkray/passes/llmtransforms.py
+++ b/src/shrinkray/passes/llmtransforms.py
@@ -74,6 +74,12 @@ MAX_ADOPTIONS = 20
 # targets can't stall the reduction on one pump.
 MAX_COMPLETIONS = 50
 
+# How many completions to try per distinct prompt (with fresh seeds)
+# before giving up on that target. Sampling means a single bad answer
+# is common even when the model usually gets the rewrite right; a
+# couple of retries recovers those cheaply.
+MAX_PROMPT_ATTEMPTS = 3
+
 
 # Node types whose underscore-separated words intersect these are taken
 # to be function definitions / calls. This convention holds across the
@@ -239,6 +245,7 @@ def llm_transform_pump(
     *,
     max_adoptions: int = MAX_ADOPTIONS,
     max_completions: int = MAX_COMPLETIONS,
+    max_prompt_attempts: int = MAX_PROMPT_ATTEMPTS,
 ) -> ReductionPump[bytes]:
     """A pump applying one grammar-guided transformation with the model.
 
@@ -246,54 +253,73 @@ def llm_transform_pump(
     targets, and asks the model to rewrite one span at a time; whenever
     a spliced candidate is interesting it is adopted and the targets
     are rederived (adoption shifts every later span). Responses are
-    memoized by prompt, so rederiving doesn't re-ask the model about
-    targets it has already answered for.
+    remembered per prompt: rederived targets replay earlier answers
+    before asking again, and a prompt whose answers all failed is
+    retried with a fresh seed up to max_prompt_attempts times, since a
+    single bad sample is common even when the model usually gets the
+    rewrite right.
     """
 
     async def pump(problem: ReductionProblem[bytes]) -> bytes:
         current = problem.current_test_case
         seen = {current}
-        responses: dict[str, str] = {}
+        responses: dict[str, list[str]] = {}
         completions = 0
         adoptions = 0
-        improved = True
-        while improved and adoptions < max_adoptions:
+
+        async def try_response(response: str, span: tuple[int, int]) -> bool:
+            nonlocal current, adoptions
+            for replacement in extract_candidates(response):
+                candidate = splice(current, span, replacement.strip())
+                if candidate in seen:
+                    continue
+                seen.add(candidate)
+                if await problem.is_interesting(candidate):
+                    current = candidate
+                    adoptions += 1
+                    return True
+            return False
+
+        while adoptions < max_adoptions:
             improved = False
+            asked = False
             for target in find_targets(parse_tree(language, current), current):
                 prompt = transform_prompt(target)
-                if prompt in responses:
-                    response = responses[prompt]
-                else:
-                    if completions >= max_completions:
-                        return current
-                    # The model may still be downloading or loading in
-                    # the background; wait only now that there is a
-                    # target that needs it.
-                    await client.wait_until_ready()
-                    if client.is_disabled():
-                        return current
-                    completions += 1
-                    response = await client.complete(
-                        prompt,
-                        max_tokens=completion_max_tokens(
-                            len(target.context) + len(target.text)
-                        ),
-                        seed=problem.work.random.getrandbits(32),
-                        temperature=config.temperature,
-                    )
-                    responses[prompt] = response
-                for replacement in extract_candidates(response):
-                    candidate = splice(current, target.span, replacement.strip())
-                    if candidate in seen:
-                        continue
-                    seen.add(candidate)
-                    if await problem.is_interesting(candidate):
-                        current = candidate
-                        adoptions += 1
+                cached = responses.setdefault(prompt, [])
+                # Adoption shifts spans, so a previously useless answer
+                # can produce a fresh candidate on the new state.
+                for response in cached:
+                    if await try_response(response, target.span):
                         improved = True
                         break
                 if improved:
                     break
+                if len(cached) >= max_prompt_attempts:
+                    continue
+                if completions >= max_completions:
+                    return current
+                # The model may still be downloading or loading in the
+                # background; wait only now that there is a target that
+                # needs it.
+                await client.wait_until_ready()
+                if client.is_disabled():
+                    return current
+                completions += 1
+                asked = True
+                response = await client.complete(
+                    prompt,
+                    max_tokens=completion_max_tokens(
+                        len(target.context) + len(target.text)
+                    ),
+                    seed=problem.work.random.getrandbits(32),
+                    temperature=config.temperature,
+                )
+                cached.append(response)
+                if await try_response(response, target.span):
+                    improved = True
+                    break
+            if not improved and not asked:
+                break
         return current
 
     pump.__name__ = name

--- a/src/shrinkray/passes/llmtransforms.py
+++ b/src/shrinkray/passes/llmtransforms.py
@@ -1,0 +1,315 @@
+"""Grammar-guided LLM transformation pumps.
+
+Some transformations help reduction in nearly every language. Inlining
+a function call is the canonical example: it usually makes the file
+bigger, but afterwards the function definition may be deletable, for a
+large net win. Shrink Ray implements this by hand for C and C++
+(:mod:`shrinkray.passes.cpp`), but a hand-written inliner needs
+per-language knowledge of syntax, so that approach doesn't scale across
+languages.
+
+These pumps combine two features that individually can't do the job:
+
+- A tree-sitter grammar can *identify* the ingredients of such a
+  transformation in any language it covers (here: a function
+  definition and a call to it) but cannot perform the rewrite.
+- A language model can *perform* the rewrite, but is unreliable at
+  leaving the rest of the file alone when asked to rewrite whole files.
+
+So tree-sitter picks the byte span to rewrite, the model is asked for
+replacement text for that span only, and the replacement is spliced in
+with the rest of the file untouched byte-for-byte. A wrong rewrite
+produces a candidate that fails the interestingness test and is
+discarded, so an imperfect model costs time but never correctness.
+"""
+
+from collections.abc import Callable
+
+import tree_sitter
+from attrs import frozen
+
+from shrinkray.passes.definitions import ReductionPump
+from shrinkray.passes.llm import (
+    LLMClient,
+    LLMConfig,
+    completion_max_tokens,
+    extract_candidates,
+)
+from shrinkray.passes.treesitter import iter_nodes, parse_tree
+from shrinkray.problem import ReductionProblem
+
+
+@frozen
+class TransformTarget:
+    """One place in the file a transformation could be applied."""
+
+    # The byte range of the current test case to replace.
+    span: tuple[int, int]
+
+    # The text of that range.
+    text: str
+
+    # What to ask the model to do to it.
+    instruction: str
+
+    # Supporting code the model needs to see (e.g. the definition of
+    # the function being inlined).
+    context: str
+
+
+TargetFinder = Callable[[tree_sitter.Tree, bytes], list[TransformTarget]]
+
+
+# Definitions and calls bigger than this are not offered to the model:
+# past this size the rewrite is unlikely to succeed and the prompt and
+# completion get expensive.
+MAX_SNIPPET_BYTES = 2048
+
+# Bound on how many candidates a pump adopts in a single invocation.
+# Pumps get rerun by the reducer as long as they lead to progress, so
+# this only limits how much one invocation can balloon the test case.
+MAX_ADOPTIONS = 20
+
+# Bound on model calls in a single invocation, so a file with very many
+# targets can't stall the reduction on one pump.
+MAX_COMPLETIONS = 50
+
+
+# Node types whose underscore-separated words intersect these are taken
+# to be function definitions / calls. This convention holds across the
+# tree-sitter grammars: function_definition (Python, C, C++),
+# function_declaration (Go, JavaScript), function_item (Rust),
+# method_declaration (Java), method (Ruby), call, call_expression,
+# method_invocation, ...
+_DEFINITION_WORDS = frozenset({"function", "method"})
+_CALL_WORDS = frozenset({"call", "invocation"})
+
+
+def _matches(node_type: str, words: frozenset[str]) -> bool:
+    return not words.isdisjoint(node_type.split("_"))
+
+
+def _definition_name(node: tree_sitter.Node) -> tree_sitter.Node | None:
+    """The identifier a function definition binds, or None.
+
+    Most grammars expose a `name` field directly; C and C++ bury the
+    name inside a chain of `declarator` fields (pointer declarators,
+    function declarators) ending at an identifier.
+    """
+    name = node.child_by_field_name("name")
+    if name is not None:
+        return name
+    declarator = node.child_by_field_name("declarator")
+    while declarator is not None:
+        if declarator.child_count == 0 and "identifier" in declarator.type:
+            return declarator
+        declarator = declarator.child_by_field_name("declarator")
+    return None
+
+
+def _callee_name(node: tree_sitter.Node) -> tree_sitter.Node | None:
+    """The plain identifier a call names, or None.
+
+    Calls with a receiver (`obj.f(x)`) are excluded: inlining them
+    needs the receiver expression, which this transformation doesn't
+    model. Grammars put the callee under `function` (most languages),
+    `name` (Java) or `method` (Ruby); anything else call-shaped (e.g.
+    Rust macro invocations) has no callee to match.
+    """
+    if (
+        node.child_by_field_name("object") is not None
+        or node.child_by_field_name("receiver") is not None
+    ):
+        return None
+    for field in ("function", "name", "method"):
+        callee = node.child_by_field_name(field)
+        if callee is not None:
+            if callee.child_count == 0 and "identifier" in callee.type:
+                return callee
+            return None
+    return None
+
+
+def inline_call_targets(
+    tree: tree_sitter.Tree, source: bytes
+) -> list[TransformTarget]:
+    """Calls to functions defined in the file, paired with instructions
+    to inline them.
+
+    Only unambiguous targets are produced: the callee must be a plain
+    identifier naming exactly one definition (overloaded names are
+    skipped), the call must not be inside that definition (recursion),
+    and both must be small enough to prompt with.
+    """
+    definitions: dict[bytes, tree_sitter.Node | None] = {}
+    for node in iter_nodes(tree):
+        if not node.is_named or not _matches(node.type, _DEFINITION_WORDS):
+            continue
+        # Bodiless function-like nodes (declarations, interface
+        # members, C declarators) define nothing to inline.
+        if node.child_by_field_name("body") is None:
+            continue
+        name_node = _definition_name(node)
+        if name_node is None:
+            continue
+        name = source[name_node.start_byte : name_node.end_byte]
+        definitions[name] = None if name in definitions else node
+
+    inlinable: dict[bytes, tuple[tuple[int, int], str, str]] = {}
+    for name, definition in definitions.items():
+        if definition is None:
+            continue
+        if definition.end_byte - definition.start_byte > MAX_SNIPPET_BYTES:
+            continue
+        try:
+            context = source[definition.start_byte : definition.end_byte].decode(
+                "utf-8"
+            )
+            name_text = name.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+        span = (definition.start_byte, definition.end_byte)
+        inlinable[name] = (span, name_text, context)
+
+    targets: list[TransformTarget] = []
+    for node in iter_nodes(tree):
+        if not node.is_named or not _matches(node.type, _CALL_WORDS):
+            continue
+        callee = _callee_name(node)
+        if callee is None:
+            continue
+        entry = inlinable.get(source[callee.start_byte : callee.end_byte])
+        if entry is None:
+            continue
+        definition_span, name_text, context = entry
+        if (
+            definition_span[0] <= node.start_byte
+            and node.end_byte <= definition_span[1]
+        ):
+            continue
+        if node.end_byte - node.start_byte > MAX_SNIPPET_BYTES:
+            continue
+        try:
+            text = source[node.start_byte : node.end_byte].decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+        targets.append(
+            TransformTarget(
+                span=(node.start_byte, node.end_byte),
+                text=text,
+                instruction=(
+                    f"Inline this call to the function `{name_text}`: "
+                    "substitute the argument expressions for its "
+                    "parameters and produce an equivalent inline "
+                    "replacement for the call, parenthesised if needed. "
+                    "The replacement must preserve the code's behaviour."
+                ),
+                context=context,
+            )
+        )
+    return targets
+
+
+def transform_prompt(target: TransformTarget) -> str:
+    """The prompt asking the model to rewrite one target."""
+    return (
+        "You are helping to minimize a test case by applying a small "
+        "mechanical refactoring to one piece of it.\n\n"
+        f"{target.instruction}\n\n"
+        "For reference:\n\n"
+        f"```\n{target.context}\n```\n\n"
+        "The code to rewrite is:\n\n"
+        f"```\n{target.text}\n```\n\n"
+        "Output only the replacement code, in a single fenced code "
+        "block. Output nothing else: no explanations, no commentary."
+    )
+
+
+def splice(source: bytes, span: tuple[int, int], replacement: bytes) -> bytes:
+    """source with the bytes in span replaced by replacement."""
+    return source[: span[0]] + replacement + source[span[1] :]
+
+
+def llm_transform_pump(
+    client: LLMClient,
+    config: LLMConfig,
+    language: str,
+    name: str,
+    find_targets: TargetFinder,
+    *,
+    max_adoptions: int = MAX_ADOPTIONS,
+    max_completions: int = MAX_COMPLETIONS,
+) -> ReductionPump[bytes]:
+    """A pump applying one grammar-guided transformation with the model.
+
+    Each round parses the current result, finds the transformation's
+    targets, and asks the model to rewrite one span at a time; whenever
+    a spliced candidate is interesting it is adopted and the targets
+    are rederived (adoption shifts every later span). Responses are
+    memoized by prompt, so rederiving doesn't re-ask the model about
+    targets it has already answered for.
+    """
+
+    async def pump(problem: ReductionProblem[bytes]) -> bytes:
+        current = problem.current_test_case
+        seen = {current}
+        responses: dict[str, str] = {}
+        completions = 0
+        adoptions = 0
+        improved = True
+        while improved and adoptions < max_adoptions:
+            improved = False
+            for target in find_targets(parse_tree(language, current), current):
+                prompt = transform_prompt(target)
+                if prompt in responses:
+                    response = responses[prompt]
+                else:
+                    if completions >= max_completions:
+                        return current
+                    # The model may still be downloading or loading in
+                    # the background; wait only now that there is a
+                    # target that needs it.
+                    await client.wait_until_ready()
+                    if client.is_disabled():
+                        return current
+                    completions += 1
+                    response = await client.complete(
+                        prompt,
+                        max_tokens=completion_max_tokens(
+                            len(target.context) + len(target.text)
+                        ),
+                        seed=problem.work.random.getrandbits(32),
+                        temperature=config.temperature,
+                    )
+                    responses[prompt] = response
+                for replacement in extract_candidates(response):
+                    candidate = splice(current, target.span, replacement.strip())
+                    if candidate in seen:
+                        continue
+                    seen.add(candidate)
+                    if await problem.is_interesting(candidate):
+                        current = candidate
+                        adoptions += 1
+                        improved = True
+                        break
+                if improved:
+                    break
+        return current
+
+    pump.__name__ = name
+    return pump
+
+
+def llm_transform_pumps(
+    client: LLMClient, config: LLMConfig, language: str
+) -> list[ReductionPump[bytes]]:
+    """The grammar-guided LLM pumps for a language."""
+    return [
+        llm_transform_pump(
+            client,
+            config,
+            language,
+            f"llm_inline_calls({language})",
+            inline_call_targets,
+        ),
+    ]

--- a/src/shrinkray/passes/llmtransforms.py
+++ b/src/shrinkray/passes/llmtransforms.py
@@ -231,9 +231,7 @@ def _callee_name(node: tree_sitter.Node) -> tree_sitter.Node | None:
     return None
 
 
-def inline_call_targets(
-    tree: tree_sitter.Tree, source: bytes
-) -> list[TransformTarget]:
+def inline_call_targets(tree: tree_sitter.Tree, source: bytes) -> list[TransformTarget]:
     """Calls to functions defined in the file, paired with instructions
     to inline them.
 
@@ -242,6 +240,7 @@ def inline_call_targets(
     skipped), the call must not be inside that definition (recursion),
     and both must be small enough to prompt with.
     """
+
     def named_definitions() -> Iterable[tuple[bytes, tree_sitter.Node]]:
         for node in iter_nodes(tree):
             if not node.is_named or not _matches(node.type, _DEFINITION_WORDS):
@@ -292,9 +291,7 @@ def inline_call_targets(
     return targets
 
 
-def _binding_name(
-    node: tree_sitter.Node, source: bytes
-) -> tree_sitter.Node | None:
+def _binding_name(node: tree_sitter.Node, source: bytes) -> tree_sitter.Node | None:
     """The name child of a node binding one plain identifier to a value
     or type, or None."""
     if not _matches(node.type, _BINDING_WORDS):

--- a/src/shrinkray/passes/llmtransforms.py
+++ b/src/shrinkray/passes/llmtransforms.py
@@ -8,6 +8,20 @@ large net win. Shrink Ray implements this by hand for C and C++
 per-language knowledge of syntax, so that approach doesn't scale across
 languages.
 
+The transformations (see TRANSFORMATIONS):
+
+- inline_calls: replace a call with the called function's body,
+  arguments substituted (generalises the C/C++ simple inliner).
+- inline_definitions: replace a use of a once-bound name (variable,
+  constant, type alias, C macro) with its definition (generalises
+  typedef inlining).
+- stub_bodies: replace a function body with a minimal valid stub,
+  returning a trivial constant where one is required (generalises
+  function-def-to-decl and replace-body-with-ellipsis).
+- unroll_loops: replace a loop with its first iteration as
+  straight-line code.
+- evaluate_constants: fold a constant expression to a literal.
+
 These pumps combine two features that individually can't do the job:
 
 - A tree-sitter grammar can *identify* the ingredients of such a
@@ -89,6 +103,53 @@ MAX_PROMPT_ATTEMPTS = 3
 # method_invocation, ...
 _DEFINITION_WORDS = frozenset({"function", "method"})
 _CALL_WORDS = frozenset({"call", "invocation"})
+
+# Node types that bind a name: assignment (Python, Ruby),
+# init_declarator / variable_declarator (C, JavaScript, Java),
+# let_declaration (Rust), var_spec / const_spec (Go), type_definition /
+# alias_declaration / type_item (typedefs and type aliases), preproc_def
+# (C macros). Deliberately absent: "parameter" (default values are not
+# bindings of the call sites' values), "binary"/"unary" (expressions
+# have left/right fields but bind nothing).
+_BINDING_WORDS = frozenset(
+    {
+        "assignment",
+        "declarator",
+        "declaration",
+        "spec",
+        "item",
+        "let",
+        "definition",
+        "typedef",
+        "using",
+        "alias",
+        "def",
+    }
+)
+
+# Binding nodes whose type words intersect these carry their definition
+# in a `type` field rather than `value`/`right` (typedefs and aliases).
+_TYPE_VALUE_WORDS = frozenset({"type", "alias", "typedef"})
+
+_BINDING_NAME_FIELDS = ("name", "left", "declarator", "pattern")
+
+# Loop node types: for_statement, while_statement, for_expression,
+# loop_expression, repeat_statement, while, for, until (Ruby)...
+# Requiring a `body` field excludes non-loop matches like Python's
+# comprehension for_in_clause and Go's for_clause.
+_LOOP_WORDS = frozenset({"for", "while", "loop", "repeat", "foreach", "until"})
+
+# Expression node types eligible for constant folding: binary_operator,
+# binary_expression, unary_expression, ...
+_CONSTANT_EXPRESSION_WORDS = frozenset({"binary", "unary"})
+
+# Constant expressions shorter than this cannot usefully fold: the
+# replacement literal would be no smaller.
+MIN_CONSTANT_BYTES = 3
+
+# Function bodies at most this size are not worth stubbing: the stub
+# would be no smaller, and mechanical passes empty them anyway.
+MIN_STUB_BODY_BYTES = 16
 
 
 def _matches(node_type: str, words: frozenset[str]) -> bool:
@@ -216,14 +277,242 @@ def inline_call_targets(
     return targets
 
 
+def _binding_parts(
+    node: tree_sitter.Node,
+) -> tuple[tree_sitter.Node, tree_sitter.Node] | None:
+    """The (name, definition) children of a node binding one plain
+    identifier to a value or type, or None."""
+    if not _matches(node.type, _BINDING_WORDS):
+        return None
+    value = node.child_by_field_name("value")
+    if value is None:
+        value = node.child_by_field_name("right")
+    if value is None and _matches(node.type, _TYPE_VALUE_WORDS):
+        value = node.child_by_field_name("type")
+    if value is None:
+        return None
+    for field in _BINDING_NAME_FIELDS:
+        name = node.child_by_field_name(field)
+        if name is None:
+            continue
+        if name.child_count == 0 and "identifier" in name.type:
+            return (name, value)
+        # A structured binding (tuple pattern, expression list): not
+        # one name bound to one definition.
+        return None
+    return None
+
+
+def inline_definition_targets(
+    tree: tree_sitter.Tree, source: bytes
+) -> list[TransformTarget]:
+    """Uses of names bound once to a value or type, paired with
+    instructions to inline the definition into the use.
+
+    This generalises typedef inlining: variables, constants, type
+    aliases and C macros all bind a name whose uses can be replaced by
+    the definition, after which the binding itself is deletable. Names
+    bound more than once (reassignment, augmented assignment) are
+    skipped: their value at a given use is not the textual definition.
+    """
+    bindings: dict[bytes, tree_sitter.Node | None] = {}
+    for node in iter_nodes(tree):
+        if not node.is_named:
+            continue
+        parts = _binding_parts(node)
+        if parts is None:
+            continue
+        name_node = parts[0]
+        name = source[name_node.start_byte : name_node.end_byte]
+        bindings[name] = None if name in bindings else node
+
+    inlinable: dict[bytes, tuple[tuple[int, int], str, str]] = {}
+    for name, binding in bindings.items():
+        if binding is None:
+            continue
+        if binding.end_byte - binding.start_byte > MAX_SNIPPET_BYTES:
+            continue
+        try:
+            context = source[binding.start_byte : binding.end_byte].decode("utf-8")
+            name_text = name.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+        inlinable[name] = (
+            (binding.start_byte, binding.end_byte),
+            name_text,
+            context.strip(),
+        )
+
+    targets: list[TransformTarget] = []
+    for node in iter_nodes(tree):
+        if node.child_count != 0 or "identifier" not in node.type:
+            continue
+        entry = inlinable.get(source[node.start_byte : node.end_byte])
+        if entry is None:
+            continue
+        binding_span, name_text, context = entry
+        if binding_span[0] <= node.start_byte and node.end_byte <= binding_span[1]:
+            continue
+        targets.append(
+            TransformTarget(
+                span=(node.start_byte, node.end_byte),
+                text=name_text,
+                instruction=(
+                    f"Replace this use of `{name_text}` with the value or "
+                    "type it is defined as, substituted in place. Add "
+                    "parentheses only if they are needed to keep the "
+                    "meaning unchanged."
+                ),
+                context=context,
+            )
+        )
+    return targets
+
+
+def _is_identifier_free(node: tree_sitter.Node) -> bool:
+    """Whether an expression mentions no names and makes no calls, so
+    its value is determined by the expression text alone."""
+    stack = [node]
+    while stack:
+        n = stack.pop()
+        if "identifier" in n.type or _matches(n.type, _CALL_WORDS):
+            return False
+        stack.extend(n.children)
+    return True
+
+
+def constant_expression_targets(
+    tree: tree_sitter.Tree, source: bytes
+) -> list[TransformTarget]:
+    """Maximal constant expressions, paired with instructions to fold
+    them to a literal.
+
+    Mechanical folding (combine_expressions) only handles simple
+    integer arithmetic; the model folds strings, floats, bit
+    operations, and every language's own literal syntax.
+    """
+    targets: list[TransformTarget] = []
+    stack = [tree.root_node]
+    while stack:
+        node = stack.pop()
+        if (
+            node.is_named
+            and _matches(node.type, _CONSTANT_EXPRESSION_WORDS)
+            and MIN_CONSTANT_BYTES
+            <= node.end_byte - node.start_byte
+            <= MAX_SNIPPET_BYTES
+            and _is_identifier_free(node)
+        ):
+            try:
+                text = source[node.start_byte : node.end_byte].decode("utf-8")
+            except UnicodeDecodeError:
+                text = None
+            if text is not None:
+                targets.append(
+                    TransformTarget(
+                        span=(node.start_byte, node.end_byte),
+                        text=text,
+                        instruction=(
+                            "Evaluate this constant expression and replace "
+                            "it with its simplest literal value."
+                        ),
+                        context="",
+                    )
+                )
+                # Maximal expressions only: folding a subexpression of a
+                # foldable expression is strictly worse.
+                continue
+        stack.extend(node.children)
+    return targets
+
+
+def loop_targets(tree: tree_sitter.Tree, source: bytes) -> list[TransformTarget]:
+    """Loops, paired with instructions to unroll a single iteration.
+
+    Replacing a loop with its first iteration's straight-line code
+    deletes the loop scaffolding and often unblocks deleting whatever
+    only the loop used. No mechanical pass can do the variable
+    substitution this needs.
+    """
+    targets: list[TransformTarget] = []
+    for node in iter_nodes(tree):
+        if not node.is_named or not _matches(node.type, _LOOP_WORDS):
+            continue
+        if node.child_by_field_name("body") is None:
+            continue
+        if node.end_byte - node.start_byte > MAX_SNIPPET_BYTES:
+            continue
+        try:
+            text = source[node.start_byte : node.end_byte].decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+        targets.append(
+            TransformTarget(
+                span=(node.start_byte, node.end_byte),
+                text=text,
+                instruction=(
+                    "Rewrite this loop as straight-line code that executes "
+                    "the loop body exactly once, with the loop variable "
+                    "(if any) bound to the first value it would take."
+                ),
+                context="",
+            )
+        )
+    return targets
+
+
+def stub_body_targets(tree: tree_sitter.Tree, source: bytes) -> list[TransformTarget]:
+    """Function bodies, paired with instructions to replace them with a
+    minimal stub.
+
+    Mechanical hollowing empties brackets, but an empty body is invalid
+    where a return value is required (Go, Rust, non-void C++ under
+    -Werror); the model can synthesize the smallest body that still
+    returns something of the right type.
+    """
+    targets: list[TransformTarget] = []
+    for node in iter_nodes(tree):
+        if not node.is_named or not _matches(node.type, _DEFINITION_WORDS):
+            continue
+        body = node.child_by_field_name("body")
+        if body is None:
+            continue
+        if not (
+            MIN_STUB_BODY_BYTES < body.end_byte - body.start_byte <= MAX_SNIPPET_BYTES
+        ):
+            continue
+        try:
+            signature = source[node.start_byte : body.start_byte].decode("utf-8")
+            text = source[body.start_byte : body.end_byte].decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+        targets.append(
+            TransformTarget(
+                span=(body.start_byte, body.end_byte),
+                text=text,
+                instruction=(
+                    "Replace this function body with the smallest body that "
+                    "still parses and type-checks: return a trivial constant "
+                    "if the function must return a value, otherwise do as "
+                    "little as possible. Keep the original body's delimiters "
+                    "and indentation style."
+                ),
+                context=signature.strip(),
+            )
+        )
+    return targets
+
+
 def transform_prompt(target: TransformTarget) -> str:
     """The prompt asking the model to rewrite one target."""
+    reference = (
+        f"For reference:\n\n```\n{target.context}\n```\n\n" if target.context else ""
+    )
     return (
         "You are helping to minimize a test case by applying a small "
         "mechanical refactoring to one piece of it.\n\n"
         f"{target.instruction}\n\n"
-        "For reference:\n\n"
-        f"```\n{target.context}\n```\n\n"
+        f"{reference}"
         "The code to rewrite is:\n\n"
         f"```\n{target.text}\n```\n\n"
         "Output only the replacement code, in a single fenced code "
@@ -326,16 +615,24 @@ def llm_transform_pump(
     return pump
 
 
+# The transformations, in rough order of expected value: the inlining
+# transformations unlock deleting whole definitions, stubbing and
+# unrolling unlock deleting what a body or loop used, and constant
+# folding mostly polishes.
+TRANSFORMATIONS: list[tuple[str, TargetFinder]] = [
+    ("llm_inline_calls", inline_call_targets),
+    ("llm_inline_definitions", inline_definition_targets),
+    ("llm_stub_bodies", stub_body_targets),
+    ("llm_unroll_loops", loop_targets),
+    ("llm_evaluate_constants", constant_expression_targets),
+]
+
+
 def llm_transform_pumps(
     client: LLMClient, config: LLMConfig, language: str
 ) -> list[ReductionPump[bytes]]:
     """The grammar-guided LLM pumps for a language."""
     return [
-        llm_transform_pump(
-            client,
-            config,
-            language,
-            f"llm_inline_calls({language})",
-            inline_call_targets,
-        ),
+        llm_transform_pump(client, config, language, f"{name}({language})", finder)
+        for name, finder in TRANSFORMATIONS
     ]

--- a/src/shrinkray/passes/llmtransforms.py
+++ b/src/shrinkray/passes/llmtransforms.py
@@ -37,7 +37,7 @@ produces a candidate that fails the interestingness test and is
 discarded, so an imperfect model costs time but never correctness.
 """
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 
 import tree_sitter
 from attrs import frozen
@@ -156,6 +156,40 @@ def _matches(node_type: str, words: frozenset[str]) -> bool:
     return not words.isdisjoint(node_type.split("_"))
 
 
+def _contains(span: tuple[int, int], node: tree_sitter.Node) -> bool:
+    return span[0] <= node.start_byte and node.end_byte <= span[1]
+
+
+def _unique_definitions(
+    source: bytes, named_nodes: Iterable[tuple[bytes, tree_sitter.Node]]
+) -> dict[bytes, tuple[tuple[int, int], str, str]]:
+    """Map each name defined by exactly one of the given nodes to that
+    node's (span, decoded name, decoded text).
+
+    This is the shared notion of "the definition a name can be replaced
+    by" for both inlining transformations: ambiguous names (defined by
+    more than one node), oversized nodes, and undecodable text are all
+    dropped.
+    """
+    nodes: dict[bytes, tree_sitter.Node | None] = {}
+    for name, node in named_nodes:
+        nodes[name] = None if name in nodes else node
+
+    result: dict[bytes, tuple[tuple[int, int], str, str]] = {}
+    for name, node in nodes.items():
+        if node is None:
+            continue
+        if node.end_byte - node.start_byte > MAX_SNIPPET_BYTES:
+            continue
+        try:
+            context = source[node.start_byte : node.end_byte].decode("utf-8")
+            name_text = name.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+        result[name] = ((node.start_byte, node.end_byte), name_text, context.strip())
+    return result
+
+
 def _definition_name(node: tree_sitter.Node) -> tree_sitter.Node | None:
     """The identifier a function definition binds, or None.
 
@@ -208,36 +242,20 @@ def inline_call_targets(
     skipped), the call must not be inside that definition (recursion),
     and both must be small enough to prompt with.
     """
-    definitions: dict[bytes, tree_sitter.Node | None] = {}
-    for node in iter_nodes(tree):
-        if not node.is_named or not _matches(node.type, _DEFINITION_WORDS):
-            continue
-        # Bodiless function-like nodes (declarations, interface
-        # members, C declarators) define nothing to inline.
-        if node.child_by_field_name("body") is None:
-            continue
-        name_node = _definition_name(node)
-        if name_node is None:
-            continue
-        name = source[name_node.start_byte : name_node.end_byte]
-        definitions[name] = None if name in definitions else node
+    def named_definitions() -> Iterable[tuple[bytes, tree_sitter.Node]]:
+        for node in iter_nodes(tree):
+            if not node.is_named or not _matches(node.type, _DEFINITION_WORDS):
+                continue
+            # Bodiless function-like nodes (declarations, interface
+            # members, C declarators) define nothing to inline.
+            if node.child_by_field_name("body") is None:
+                continue
+            name_node = _definition_name(node)
+            if name_node is None:
+                continue
+            yield source[name_node.start_byte : name_node.end_byte], node
 
-    inlinable: dict[bytes, tuple[tuple[int, int], str, str]] = {}
-    for name, definition in definitions.items():
-        if definition is None:
-            continue
-        if definition.end_byte - definition.start_byte > MAX_SNIPPET_BYTES:
-            continue
-        try:
-            context = source[definition.start_byte : definition.end_byte].decode(
-                "utf-8"
-            )
-            name_text = name.decode("utf-8")
-        except UnicodeDecodeError:
-            continue
-        span = (definition.start_byte, definition.end_byte)
-        inlinable[name] = (span, name_text, context)
-
+    inlinable = _unique_definitions(source, named_definitions())
     targets: list[TransformTarget] = []
     for node in iter_nodes(tree):
         if not node.is_named or not _matches(node.type, _CALL_WORDS):
@@ -249,10 +267,7 @@ def inline_call_targets(
         if entry is None:
             continue
         definition_span, name_text, context = entry
-        if (
-            definition_span[0] <= node.start_byte
-            and node.end_byte <= definition_span[1]
-        ):
+        if _contains(definition_span, node):
             continue
         if node.end_byte - node.start_byte > MAX_SNIPPET_BYTES:
             continue
@@ -277,11 +292,11 @@ def inline_call_targets(
     return targets
 
 
-def _binding_parts(
+def _binding_name(
     node: tree_sitter.Node, source: bytes
-) -> tuple[tree_sitter.Node, tree_sitter.Node] | None:
-    """The (name, definition) children of a node binding one plain
-    identifier to a value or type, or None."""
+) -> tree_sitter.Node | None:
+    """The name child of a node binding one plain identifier to a value
+    or type, or None."""
     if not _matches(node.type, _BINDING_WORDS):
         return None
     # An augmented assignment (`x += 1`) reads the name's prior value
@@ -303,7 +318,7 @@ def _binding_parts(
         if name is None:
             continue
         if name.child_count == 0 and "identifier" in name.type:
-            return (name, value)
+            return name
         # A structured binding (tuple pattern, expression list): not
         # one name bound to one definition.
         return None
@@ -319,37 +334,23 @@ def inline_definition_targets(
     This generalises typedef inlining: variables, constants, type
     aliases and C macros all bind a name whose uses can be replaced by
     the definition, after which the binding itself is deletable. Names
-    bound more than once (reassignment, augmented assignment) are
-    skipped: their value at a given use is not the textual definition.
+    bound more than once (reassignment) are skipped: their value at a
+    given use is not the textual definition. Uses that textually precede
+    the binding are still offered: inside a function body they can
+    legitimately refer to a binding made later, and a use the rewrite
+    gets wrong just fails the interestingness test.
     """
-    bindings: dict[bytes, tree_sitter.Node | None] = {}
-    for node in iter_nodes(tree):
-        if not node.is_named:
-            continue
-        parts = _binding_parts(node, source)
-        if parts is None:
-            continue
-        name_node = parts[0]
-        name = source[name_node.start_byte : name_node.end_byte]
-        bindings[name] = None if name in bindings else node
 
-    inlinable: dict[bytes, tuple[tuple[int, int], str, str]] = {}
-    for name, binding in bindings.items():
-        if binding is None:
-            continue
-        if binding.end_byte - binding.start_byte > MAX_SNIPPET_BYTES:
-            continue
-        try:
-            context = source[binding.start_byte : binding.end_byte].decode("utf-8")
-            name_text = name.decode("utf-8")
-        except UnicodeDecodeError:
-            continue
-        inlinable[name] = (
-            (binding.start_byte, binding.end_byte),
-            name_text,
-            context.strip(),
-        )
+    def named_bindings() -> Iterable[tuple[bytes, tree_sitter.Node]]:
+        for node in iter_nodes(tree):
+            if not node.is_named:
+                continue
+            name_node = _binding_name(node, source)
+            if name_node is None:
+                continue
+            yield source[name_node.start_byte : name_node.end_byte], node
 
+    inlinable = _unique_definitions(source, named_bindings())
     targets: list[TransformTarget] = []
     for node in iter_nodes(tree):
         if node.child_count != 0 or "identifier" not in node.type:
@@ -358,7 +359,7 @@ def inline_definition_targets(
         if entry is None:
             continue
         binding_span, name_text, context = entry
-        if binding_span[0] <= node.start_byte and node.end_byte <= binding_span[1]:
+        if _contains(binding_span, node):
             continue
         targets.append(
             TransformTarget(

--- a/src/shrinkray/passes/llmtransforms.py
+++ b/src/shrinkray/passes/llmtransforms.py
@@ -586,10 +586,13 @@ def llm_transform_pump(
                         return True
             return False
 
+        targets: list[TransformTarget] | None = None
         while adoptions < max_adoptions:
+            if targets is None:
+                targets = find_targets(parse_tree(language, current), current)
             improved = False
             asked = False
-            for target in find_targets(parse_tree(language, current), current):
+            for target in targets:
                 prompt = transform_prompt(target)
                 cached = responses.setdefault(prompt, [])
                 # Adoption shifts spans, so a previously useless answer
@@ -624,7 +627,11 @@ def llm_transform_pump(
                 if await try_response(response, target):
                     improved = True
                     break
-            if not improved and not asked:
+            if improved:
+                # Adoption changed the test case, shifting every later
+                # span: the targets must be rederived.
+                targets = None
+            elif not asked:
                 break
         return current
 

--- a/src/shrinkray/reducer.py
+++ b/src/shrinkray/reducer.py
@@ -53,6 +53,7 @@ from shrinkray.passes.genericlanguages import (
 )
 from shrinkray.passes.json import JSON, JSON_PASSES
 from shrinkray.passes.llm import LLMClient, LLMConfig, llm_rewrite
+from shrinkray.passes.llmtransforms import llm_transform_pumps
 from shrinkray.passes.patching import PatchApplier, Patches
 from shrinkray.passes.python import is_python, python_reducer_command
 from shrinkray.passes.sat import SAT_PASSES, DimacsCNF
@@ -430,10 +431,18 @@ class ShrinkRay(Reducer[bytes]):
 
     @property
     def pumps(self) -> Iterable[ReductionPump[bytes]]:
-        if self.enable_cpp_passes and not self.llm_only:
-            return CPP_PUMPS
-        else:
+        if self.llm_only:
             return ()
+        result: list[ReductionPump[bytes]] = []
+        if self.enable_cpp_passes:
+            result.extend(CPP_PUMPS)
+        if self.llm_client is not None and self.treesitter_language is not None:
+            result.extend(
+                llm_transform_pumps(
+                    self.llm_client, self.llm_config, self.treesitter_language
+                )
+            )
+        return result
 
     @property
     def status(self) -> str:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,9 +3,10 @@ from collections.abc import Callable, Iterable
 from typing import Any
 
 import trio
-from attrs import define
+from attrs import define, field
 
 from shrinkray.passes.definitions import ReductionPass, ReductionPump
+from shrinkray.passes.llm import LLMClient
 from shrinkray.passes.python import is_python
 from shrinkray.problem import BasicReductionProblem, reflow_sort_key, shortlex
 from shrinkray.reducer import Reducer, ShrinkRay
@@ -53,6 +54,47 @@ class BasicReducer[T](Reducer[T]):
                             await self.run_pass(rp)
             if prev == self.target.current_test_case:
                 return
+
+
+@define
+class FakeLLMClient(LLMClient):
+    """Returns scripted responses in order, then empty strings."""
+
+    responses: list[str] = field(factory=list)
+    prompts: list[str] = field(factory=list)
+    seeds: list[int] = field(factory=list)
+
+    async def complete(
+        self, prompt: str, *, max_tokens: int, seed: int, temperature: float
+    ) -> str:
+        await trio.lowlevel.checkpoint()
+        self.prompts.append(prompt)
+        self.seeds.append(seed)
+        if len(self.prompts) <= len(self.responses):
+            return self.responses[len(self.prompts) - 1]
+        return ""
+
+
+@define
+class RecordingClient(FakeLLMClient):
+    """FakeLLMClient that records lifecycle events."""
+
+    events: list[str] = field(factory=list)
+
+    def start_loading(self) -> None:
+        self.events.append("start_loading")
+
+    async def wait_until_ready(self) -> None:
+        await trio.lowlevel.checkpoint()
+        self.events.append("wait_until_ready")
+
+    async def complete(
+        self, prompt: str, *, max_tokens: int, seed: int, temperature: float
+    ) -> str:
+        self.events.append("complete")
+        return await super().complete(
+            prompt, max_tokens=max_tokens, seed=seed, temperature=temperature
+        )
 
 
 def latin1_text_sort_key(data: bytes) -> Any:

--- a/tests/test_llm_passes.py
+++ b/tests/test_llm_passes.py
@@ -10,14 +10,12 @@ from typing import Any
 
 import pytest
 import trio
-from attrs import define, field
 
 from shrinkray.cli import InputType
 from shrinkray.llm_client import LlamaCppClient
 from shrinkray.passes.llm import (
     DEFAULT_MODEL_SPEC,
     HuggingFaceModel,
-    LLMClient,
     LLMConfig,
     LocalModel,
     completion_max_tokens,
@@ -32,7 +30,7 @@ from shrinkray.problem import BasicReductionProblem
 from shrinkray.reducer import DirectoryShrinkRay, ShrinkRay
 from shrinkray.state import ShrinkRayStateSingleFile
 from shrinkray.work import Volume, WorkContext
-from tests.helpers import reduce_with
+from tests.helpers import FakeLLMClient, RecordingClient, reduce_with
 
 
 # === Model spec parsing ===
@@ -142,25 +140,6 @@ def test_completion_max_tokens_scales_with_input_but_is_capped():
 
 
 # === The pass itself ===
-
-
-@define
-class FakeLLMClient(LLMClient):
-    """Returns scripted responses in order, then empty strings."""
-
-    responses: list[str] = field(factory=list)
-    prompts: list[str] = field(factory=list)
-    seeds: list[int] = field(factory=list)
-
-    async def complete(
-        self, prompt: str, *, max_tokens: int, seed: int, temperature: float
-    ) -> str:
-        await trio.lowlevel.checkpoint()
-        self.prompts.append(prompt)
-        self.seeds.append(seed)
-        if len(self.prompts) <= len(self.responses):
-            return self.responses[len(self.prompts) - 1]
-        return ""
 
 
 def test_adopts_a_valid_reduction():
@@ -457,28 +436,6 @@ def test_state_passes_llm_only_through(tmp_path):
 
 
 # === Background model loading ===
-
-
-@define
-class RecordingClient(FakeLLMClient):
-    """FakeLLMClient that records lifecycle events."""
-
-    events: list[str] = field(factory=list)
-
-    def start_loading(self) -> None:
-        self.events.append("start_loading")
-
-    async def wait_until_ready(self) -> None:
-        await trio.lowlevel.checkpoint()
-        self.events.append("wait_until_ready")
-
-    async def complete(
-        self, prompt: str, *, max_tokens: int, seed: int, temperature: float
-    ) -> str:
-        self.events.append("complete")
-        return await super().complete(
-            prompt, max_tokens=max_tokens, seed=seed, temperature=temperature
-        )
 
 
 def test_llm_rewrite_waits_for_readiness_before_generating():

--- a/tests/test_llm_transforms.py
+++ b/tests/test_llm_transforms.py
@@ -9,6 +9,7 @@ import contextlib
 import io
 import re
 import warnings
+from unittest.mock import patch
 
 import pytest
 import trio
@@ -464,6 +465,23 @@ def test_retries_a_fruitless_prompt_with_a_fresh_seed():
     assert len(client.prompts) == 2
     assert client.prompts[0] == client.prompts[1]
     assert client.seeds[0] != client.seeds[1]
+
+
+def test_reparses_only_after_an_adoption():
+    # Fruitless rounds leave the test case unchanged, so the target
+    # derivation (a full parse) must not be repeated for them.
+    client = FakeLLMClient()  # always answers with no code block
+    parses = []
+    real_parse = parse_tree
+
+    def counting_parse(language: str, source: bytes):
+        parses.append(source)
+        return real_parse(language, source)
+
+    with patch("shrinkray.passes.llmtransforms.parse_tree", counting_parse):
+        result, _ = run_pump(inline_pump(client), PY_SOURCE, lambda x: b"print" in x)
+    assert result == PY_SOURCE
+    assert len(parses) == 1
 
 
 def test_retries_per_prompt_are_bounded():

--- a/tests/test_llm_transforms.py
+++ b/tests/test_llm_transforms.py
@@ -200,6 +200,17 @@ def test_skips_reassigned_names():
     assert definition_targets("python", source) == []
 
 
+def test_skips_augmented_assignments():
+    # An augmented assignment reads the name's prior value rather than
+    # defining it, so it must not count as a binding even when it is the
+    # only assignment-like node naming the identifier (e.g. a mutated
+    # parameter).
+    python = b"def f(x):\n    x += 1\n    return x\n\nprint(f(1))\n"
+    assert definition_targets("python", python) == []
+    c = b"int f(int x) { x += 1; return x; }\n"
+    assert definition_targets("c", c) == []
+
+
 def test_skips_bindings_of_multiple_names():
     source = b"x, y = 1, 2\nprint(x)\n"
     assert definition_targets("python", source) == []

--- a/tests/test_llm_transforms.py
+++ b/tests/test_llm_transforms.py
@@ -18,11 +18,17 @@ from shrinkray.passes.cpp import CPP_PUMPS
 from shrinkray.passes.llm import LLMConfig
 from shrinkray.passes.llmtransforms import (
     MAX_SNIPPET_BYTES,
+    MIN_CONSTANT_BYTES,
+    MIN_STUB_BODY_BYTES,
     TransformTarget,
+    constant_expression_targets,
     inline_call_targets,
+    inline_definition_targets,
     llm_transform_pump,
     llm_transform_pumps,
+    loop_targets,
     splice,
+    stub_body_targets,
     transform_prompt,
 )
 from shrinkray.passes.treesitter import parse_tree
@@ -148,6 +154,207 @@ def test_skips_undecodable_calls():
     assert targets_for("python", source) == []
 
 
+# === Finding inlinable definitions ===
+
+
+def definition_targets(language: str, source: bytes) -> list[TransformTarget]:
+    return inline_definition_targets(parse_tree(language, source), source)
+
+
+def test_finds_uses_of_a_python_variable():
+    source = b"A = 10\nprint(A + A)\n"
+    targets = definition_targets("python", source)
+    assert [t.text for t in targets] == ["A", "A"]
+    for target in targets:
+        assert source[target.span[0] : target.span[1]] == b"A"
+        assert target.span[0] > source.index(b"\n")
+        assert target.context == "A = 10"
+        assert "`A`" in target.instruction
+
+
+def test_finds_uses_of_a_c_typedef():
+    source = b"typedef unsigned long UL;\nUL y;\n"
+    (target,) = definition_targets("c", source)
+    assert target.text == "UL"
+    assert target.context == "typedef unsigned long UL;"
+
+
+def test_finds_uses_of_a_c_macro():
+    source = b"#define K 10\nint x = K;\n"
+    (target,) = definition_targets("c", source)
+    assert target.text == "K"
+    assert target.context == "#define K 10"
+
+
+def test_finds_definitions_in_other_grammars():
+    js = b"const a = 10;\nconsole.log(a);\n"
+    assert [t.text for t in definition_targets("javascript", js)] == ["a"]
+    rust = b"fn main() { let x = 5; let y = x; }\n"
+    assert [t.text for t in definition_targets("rust", rust)] == ["x"]
+    go = b"package main\nconst K = 10\nfunc main() { print(K) }\n"
+    assert [t.text for t in definition_targets("go", go)] == ["K"]
+
+
+def test_skips_reassigned_names():
+    source = b"A = 10\nA = 20\nprint(A)\n"
+    assert definition_targets("python", source) == []
+
+
+def test_skips_bindings_of_multiple_names():
+    source = b"x, y = 1, 2\nprint(x)\n"
+    assert definition_targets("python", source) == []
+
+
+def test_skips_bindings_with_no_recognised_name_field():
+    # A JavaScript class field binds via a `property` field.
+    source = b"class A { x = 5; }\nconsole.log(x);\n"
+    assert definition_targets("javascript", source) == []
+
+
+def test_skips_default_parameter_values():
+    source = b"def f(x=1):\n    return x\n\nf(2)\n"
+    assert definition_targets("python", source) == []
+
+
+def test_skips_oversized_definitions_when_inlining_definitions():
+    source = b'A = "' + b"a" * MAX_SNIPPET_BYTES + b'"\nprint(A)\n'
+    assert definition_targets("python", source) == []
+
+
+def test_skips_undecodable_definitions_when_inlining_definitions():
+    source = b'A = "\xff"\nprint(A)\n'
+    assert definition_targets("python", source) == []
+
+
+# === Finding constant expressions ===
+
+
+def constant_targets(language: str, source: bytes) -> list[TransformTarget]:
+    return constant_expression_targets(parse_tree(language, source), source)
+
+
+def test_finds_a_maximal_constant_expression():
+    source = b"print(10*2+ 1)\n"
+    (target,) = constant_targets("python", source)
+    assert target.text == "10*2+ 1"
+    assert "Evaluate" in target.instruction
+    assert target.context == ""
+
+
+def test_finds_constant_string_concatenation():
+    source = b'console.log("a" + "b");\n'
+    (target,) = constant_targets("javascript", source)
+    assert target.text == '"a" + "b"'
+
+
+def test_skips_expressions_mentioning_identifiers():
+    assert constant_targets("python", b"print(a + 1)\n") == []
+
+
+def test_skips_expressions_containing_calls():
+    assert constant_targets("python", b"print(f() + 1)\n") == []
+
+
+def test_skips_tiny_constant_expressions():
+    source = b"print(-1)\n"
+    assert len(b"-1") < MIN_CONSTANT_BYTES
+    assert constant_targets("python", source) == []
+
+
+def test_skips_oversized_constant_expressions():
+    source = b'print("' + b"a" * MAX_SNIPPET_BYTES + b'" + "b")\n'
+    assert constant_targets("python", source) == []
+
+
+def test_skips_undecodable_constant_expressions():
+    source = b'print("\xff" + "a")\n'
+    assert constant_targets("python", source) == []
+
+
+# === Finding loops ===
+
+
+def loops_for(language: str, source: bytes) -> list[TransformTarget]:
+    return loop_targets(parse_tree(language, source), source)
+
+
+def test_finds_for_and_while_loops():
+    source = b"for i in [1]:\n    print(i)\nwhile x:\n    break\n"
+    targets = loops_for("python", source)
+    assert [t.text.split()[0] for t in targets] == ["for", "while"]
+    assert all("exactly once" in t.instruction for t in targets)
+    assert all(t.context == "" for t in targets)
+
+
+def test_finds_loops_in_other_grammars():
+    go = b"package main\nfunc main() { for i := 0; i < 3; i++ { print(i) } }\n"
+    assert len(loops_for("go", go)) == 1
+    ruby = b"a = 3\nwhile a > 0 do\n  a -= 1\nend\n"
+    assert len(loops_for("ruby", ruby)) == 1
+
+
+def test_nested_loops_are_separate_targets():
+    source = b"for i in [1]:\n    for j in [2]:\n        print(i + j)\n"
+    assert len(loops_for("python", source)) == 2
+
+
+def test_skips_comprehension_clauses():
+    assert loops_for("python", b"y = [i for i in [1]]\n") == []
+
+
+def test_skips_oversized_loops():
+    source = b"for i in [1]:\n    x = '" + b"a" * MAX_SNIPPET_BYTES + b"'\n"
+    assert loops_for("python", source) == []
+
+
+def test_skips_undecodable_loops():
+    source = b'for i in [1]:\n    print("\xff")\n'
+    assert loops_for("python", source) == []
+
+
+# === Finding function bodies to stub ===
+
+
+def bodies_for(language: str, source: bytes) -> list[TransformTarget]:
+    return stub_body_targets(parse_tree(language, source), source)
+
+
+def test_finds_a_python_function_body():
+    source = b"def f(x):\n    y = x + 1\n    return y * 2\n"
+    (target,) = bodies_for("python", source)
+    assert source[target.span[0] : target.span[1]] == b"y = x + 1\n    return y * 2"
+    assert "def f(x):" in target.context
+    assert "smallest body" in target.instruction
+
+
+def test_c_function_bodies_include_their_braces():
+    source = b"int f(int x) { int y = x; return y + 1; }\n"
+    (target,) = bodies_for("c", source)
+    assert target.text.startswith("{")
+    assert target.text.endswith("}")
+
+
+def test_skips_already_small_bodies():
+    source = b"def f(x):\n    return x\n"
+    assert len(b"return x") <= MIN_STUB_BODY_BYTES
+    assert bodies_for("python", source) == []
+
+
+def test_skips_class_bodies():
+    source = b"class A:\n    x = 1\n    y = 2\n    z = 3\n    w = 4\n"
+    assert bodies_for("python", source) == []
+
+
+def test_skips_oversized_bodies():
+    source = b"def f(x):\n    return '" + b"a" * MAX_SNIPPET_BYTES + b"'\n"
+    assert bodies_for("python", source) == []
+
+
+def test_skips_undecodable_bodies():
+    source = b'def f(x):\n    y = "\xff" + "aaaaaaaa"\n    return y\n'
+    assert bodies_for("python", source) == []
+
+
 # === Prompt construction and splicing ===
 
 
@@ -163,6 +370,13 @@ def test_prompt_contains_instruction_context_and_target():
     assert target.context in prompt
     assert target.text in prompt
     assert "fenced code block" in prompt
+
+
+def test_prompt_omits_reference_block_without_context():
+    (target,) = constant_targets("python", b"print(10*2+ 1)\n")
+    prompt = transform_prompt(target)
+    assert "For reference" not in prompt
+    assert target.text in prompt
 
 
 # === The pump ===
@@ -276,6 +490,48 @@ def test_max_completions_bounds_model_calls():
     )
     assert result == source
     assert len(client.prompts) == 1
+
+
+def test_inlines_a_definition_end_to_end():
+    source = b"A = 10\nprint(A)\n"
+    client = FakeLLMClient(responses=["```\n10\n```"])
+    pump = llm_transform_pump(
+        client, LLMConfig(), "python", "llm_inline_definitions(python)",
+        inline_definition_targets,
+    )
+    result, _ = run_pump(pump, source, lambda x: b"print" in x)
+    assert result == b"A = 10\nprint(10)\n"
+
+
+def test_evaluates_a_constant_end_to_end():
+    source = b"print(10*2+ 1)\n"
+    client = FakeLLMClient(responses=["```\n21\n```"])
+    pump = llm_transform_pump(
+        client, LLMConfig(), "python", "llm_evaluate_constants(python)",
+        constant_expression_targets,
+    )
+    result, _ = run_pump(pump, source, lambda x: b"print" in x)
+    assert result == b"print(21)\n"
+
+
+def test_unrolls_a_loop_end_to_end():
+    source = b"for i in [3]:\n    print(i)\n"
+    client = FakeLLMClient(responses=["```\nprint(3)\n```"])
+    pump = llm_transform_pump(
+        client, LLMConfig(), "python", "llm_unroll_loops(python)", loop_targets
+    )
+    result, _ = run_pump(pump, source, lambda x: b"print" in x)
+    assert result == b"print(3)\n"
+
+
+def test_stubs_a_body_end_to_end():
+    source = b"def f(x):\n    y = x + 1\n    return y * 2\nprint(f)\n"
+    client = FakeLLMClient(responses=["```\npass\n```"])
+    pump = llm_transform_pump(
+        client, LLMConfig(), "python", "llm_stub_bodies(python)", stub_body_targets
+    )
+    result, _ = run_pump(pump, source, lambda x: b"print" in x)
+    assert result == b"def f(x):\n    pass\nprint(f)\n"
 
 
 class DisabledClient(RecordingClient):
@@ -395,14 +651,23 @@ def pump_names(reducer: ShrinkRay) -> list[str]:
     return [p.__name__ for p in reducer.pumps]
 
 
+LLM_PUMP_NAMES = [
+    "llm_inline_calls",
+    "llm_inline_definitions",
+    "llm_stub_bodies",
+    "llm_unroll_loops",
+    "llm_evaluate_constants",
+]
+
+
 def test_llm_transform_pumps_are_named_for_their_language():
     pumps = llm_transform_pumps(FakeLLMClient(), LLMConfig(), "python")
-    assert [p.__name__ for p in pumps] == ["llm_inline_calls(python)"]
+    assert [p.__name__ for p in pumps] == [f"{n}(python)" for n in LLM_PUMP_NAMES]
 
 
 def test_reducer_builds_llm_pumps_when_fully_configured():
     reducer = make_shrinkray(llm_client=FakeLLMClient(), treesitter_language="python")
-    assert pump_names(reducer) == ["llm_inline_calls(python)"]
+    assert pump_names(reducer) == [f"{n}(python)" for n in LLM_PUMP_NAMES]
 
 
 def test_reducer_keeps_cpp_pumps_ahead_of_llm_pumps():
@@ -412,7 +677,7 @@ def test_reducer_keeps_cpp_pumps_ahead_of_llm_pumps():
         enable_cpp_passes=True,
     )
     assert pump_names(reducer) == [p.__name__ for p in CPP_PUMPS] + [
-        "llm_inline_calls(cpp)"
+        f"{n}(cpp)" for n in LLM_PUMP_NAMES
     ]
 
 

--- a/tests/test_llm_transforms.py
+++ b/tests/test_llm_transforms.py
@@ -98,7 +98,9 @@ def test_skips_java_calls_on_an_explicit_object():
 
 def test_skips_calls_with_no_recognisable_callee():
     # Rust macro invocations are call-like but name no function.
-    source = b'fn f(x: i32) -> i32 { x + 1 }\nfn main() { let y = f(3); println!("hi"); }\n'
+    source = (
+        b'fn f(x: i32) -> i32 { x + 1 }\nfn main() { let y = f(3); println!("hi"); }\n'
+    )
     assert target_texts("rust", source) == ["f(3)"]
 
 
@@ -525,7 +527,10 @@ def test_inlines_a_definition_end_to_end():
     source = b"A = 10\nprint(A)\n"
     client = FakeLLMClient(responses=["```\n10\n```"])
     pump = llm_transform_pump(
-        client, LLMConfig(), "python", "llm_inline_definitions(python)",
+        client,
+        LLMConfig(),
+        "python",
+        "llm_inline_definitions(python)",
         inline_definition_targets,
     )
     result, _ = run_pump(pump, source, lambda x: b"print" in x)
@@ -536,7 +541,10 @@ def test_evaluates_a_constant_end_to_end():
     source = b"print(10*2+ 1)\n"
     client = FakeLLMClient(responses=["```\n21\n```"])
     pump = llm_transform_pump(
-        client, LLMConfig(), "python", "llm_evaluate_constants(python)",
+        client,
+        LLMConfig(),
+        "python",
+        "llm_evaluate_constants(python)",
         constant_expression_targets,
     )
     result, _ = run_pump(pump, source, lambda x: b"print" in x)

--- a/tests/test_llm_transforms.py
+++ b/tests/test_llm_transforms.py
@@ -1,0 +1,405 @@
+"""Tests for the grammar-guided LLM transformation pumps.
+
+These use real tree-sitter grammars to find transformation targets, and
+a fake in-memory client for the model side; no model is loaded and no
+network is used.
+"""
+
+import contextlib
+import io
+import re
+import warnings
+
+import pytest
+import trio
+from attrs import define
+
+from shrinkray.passes.cpp import CPP_PUMPS
+from shrinkray.passes.llm import LLMConfig
+from shrinkray.passes.llmtransforms import (
+    MAX_SNIPPET_BYTES,
+    TransformTarget,
+    inline_call_targets,
+    llm_transform_pump,
+    llm_transform_pumps,
+    splice,
+    transform_prompt,
+)
+from shrinkray.passes.treesitter import parse_tree
+from shrinkray.problem import BasicReductionProblem
+from shrinkray.reducer import ShrinkRay
+from shrinkray.work import WorkContext
+from tests.helpers import FakeLLMClient, RecordingClient
+
+
+def targets_for(language: str, source: bytes) -> list[TransformTarget]:
+    return inline_call_targets(parse_tree(language, source), source)
+
+
+def target_texts(language: str, source: bytes) -> list[str]:
+    return [t.text for t in targets_for(language, source)]
+
+
+# === Finding inlinable calls ===
+
+
+PY_SOURCE = b"def f(x):\n    return x + 1\n\nprint(f(3))\n"
+
+
+def test_finds_a_python_call_with_its_definition():
+    (target,) = targets_for("python", PY_SOURCE)
+    assert PY_SOURCE[target.span[0] : target.span[1]] == b"f(3)"
+    assert target.text == "f(3)"
+    assert "def f(x):" in target.context
+    assert "`f`" in target.instruction
+
+
+def test_finds_a_c_call_through_the_declarator_chain():
+    source = (
+        b"int add(int x, int y) { return x + y; }\n"
+        b"int main(void) { return add(1, 2); }\n"
+    )
+    assert target_texts("c", source) == ["add(1, 2)"]
+
+
+def test_finds_calls_in_other_grammars():
+    go = b"package main\nfunc f(x int) int { return x + 1 }\nfunc main() { println(f(3)) }\n"
+    assert target_texts("go", go) == ["f(3)"]
+    js = b"function f(x) { return x + 1; }\nconsole.log(f(3));\n"
+    assert target_texts("javascript", js) == ["f(3)"]
+    ruby = b"def f(x)\n  x + 1\nend\nputs f(3)\n"
+    assert target_texts("ruby", ruby) == ["f(3)"]
+
+
+def test_skips_calls_through_an_attribute():
+    source = b"def f(x):\n    return x\n\nobj.f(3)\n"
+    assert targets_for("python", source) == []
+
+
+def test_skips_calls_with_a_receiver():
+    source = b"def f(x)\n  x + 1\nend\nobj.f(3)\n"
+    assert targets_for("ruby", source) == []
+
+
+def test_skips_java_calls_on_an_explicit_object():
+    source = (
+        b"class A { static int f(int x) { return x + 1; } "
+        b"int g() { return f(3) + this.f(4); } }\n"
+    )
+    assert target_texts("java", source) == ["f(3)"]
+
+
+def test_skips_calls_with_no_recognisable_callee():
+    # Rust macro invocations are call-like but name no function.
+    source = b'fn f(x: i32) -> i32 { x + 1 }\nfn main() { let y = f(3); println!("hi"); }\n'
+    assert target_texts("rust", source) == ["f(3)"]
+
+
+def test_skips_recursive_calls_inside_the_definition():
+    source = b"def f(x):\n    return f(x - 1)\n\nprint(f(3))\n"
+    assert target_texts("python", source) == ["f(3)"]
+
+
+def test_skips_ambiguously_overloaded_names():
+    source = (
+        b"int f(int x) { return x; }\n"
+        b"int f(int x, int y) { return x + y; }\n"
+        b"int main() { return f(1); }\n"
+    )
+    assert targets_for("cpp", source) == []
+
+
+def test_skips_calls_to_unknown_functions():
+    assert targets_for("python", b"print(g(3))\n") == []
+
+
+def test_skips_definitions_without_bodies():
+    source = b"interface I { int h(int x); }\nclass A { int g() { return h(3); } }\n"
+    assert targets_for("java", source) == []
+
+
+def test_skips_definitions_without_names():
+    source = (
+        b"struct A{}; int operator+(A a, A b) { return 0; }\n"
+        b"int main() { A x; A y; x + y; return 0; }\n"
+    )
+    assert targets_for("cpp", source) == []
+
+
+def test_skips_oversized_definitions():
+    body = b" + ".join([b"x"] * MAX_SNIPPET_BYTES)
+    source = b"def f(x):\n    return " + body + b"\n\nprint(f(3))\n"
+    assert targets_for("python", source) == []
+
+
+def test_skips_oversized_calls():
+    argument = b"'" + b"a" * MAX_SNIPPET_BYTES + b"'"
+    source = b"def f(x):\n    return x\n\nprint(f(" + argument + b"))\n"
+    assert targets_for("python", source) == []
+
+
+def test_skips_undecodable_definitions():
+    source = b'def f(x):\n    return "\xff"\n\nprint(f(3))\n'
+    assert targets_for("python", source) == []
+
+
+def test_skips_undecodable_calls():
+    source = b'def f(x):\n    return x\n\nprint(f("\xff"))\n'
+    assert targets_for("python", source) == []
+
+
+# === Prompt construction and splicing ===
+
+
+def test_splice_replaces_the_span():
+    assert splice(b"abcdef", (2, 4), b"XY") == b"abXYef"
+    assert splice(b"abcdef", (2, 4), b"") == b"abef"
+
+
+def test_prompt_contains_instruction_context_and_target():
+    (target,) = targets_for("python", PY_SOURCE)
+    prompt = transform_prompt(target)
+    assert target.instruction in prompt
+    assert target.context in prompt
+    assert target.text in prompt
+    assert "fenced code block" in prompt
+
+
+# === The pump ===
+
+
+def run_pump(pump, initial, is_interesting):
+    calls = []
+
+    async def acondition(x: bytes) -> bool:
+        await trio.lowlevel.checkpoint()
+        calls.append(x)
+        return is_interesting(x)
+
+    async def calc_result() -> bytes:
+        problem: BasicReductionProblem[bytes] = BasicReductionProblem(
+            initial=initial,
+            is_interesting=acondition,
+            work=WorkContext(parallelism=1),
+        )
+        await problem.setup()
+        return await pump(problem)
+
+    return trio.run(calc_result), calls
+
+
+def inline_pump(client, **kwargs):
+    return llm_transform_pump(
+        client,
+        LLMConfig(),
+        "python",
+        "llm_inline_calls(python)",
+        inline_call_targets,
+        **kwargs,
+    )
+
+
+def test_inlines_a_call_end_to_end():
+    client = FakeLLMClient(responses=["```\n(3 + 1)\n```"])
+    result, _ = run_pump(inline_pump(client), PY_SOURCE, lambda x: b"print" in x)
+    assert result == b"def f(x):\n    return x + 1\n\nprint((3 + 1))\n"
+    (prompt,) = client.prompts
+    assert "def f(x):" in prompt
+    assert "f(3)" in prompt
+
+
+def test_does_not_adopt_uninteresting_candidates():
+    client = FakeLLMClient(responses=["```\n(3 + 1)\n```"])
+    result, _ = run_pump(inline_pump(client), PY_SOURCE, lambda x: b"f(3)" in x)
+    assert result == PY_SOURCE
+
+
+def test_a_model_echoing_the_call_is_not_retested():
+    client = FakeLLMClient(responses=["```\nf(3)\n```"])
+    result, calls = run_pump(inline_pump(client), PY_SOURCE, lambda x: b"print" in x)
+    assert result == PY_SOURCE
+    # Only the initial test-case check; the echoed candidate is skipped.
+    assert calls == [PY_SOURCE]
+
+
+def test_identical_calls_share_one_completion():
+    source = b"def f(x):\n    return x + 1\n\nprint(f(3))\nprint(f(3))\n"
+    client = FakeLLMClient(responses=["no code block here"])
+    result, _ = run_pump(inline_pump(client), source, lambda x: b"print" in x)
+    assert result == source
+    assert len(client.prompts) == 1
+
+
+def test_rederives_targets_after_each_adoption():
+    source = b"def f(x):\n    return x + 1\n\nprint(f(3))\nprint(f(5))\n"
+    client = FakeLLMClient(responses=["```\n(3 + 1)\n```", "```\n(5 + 1)\n```"])
+    result, _ = run_pump(inline_pump(client), source, lambda x: b"print" in x)
+    assert result == b"def f(x):\n    return x + 1\n\nprint((3 + 1))\nprint((5 + 1))\n"
+    assert len(client.prompts) == 2
+
+
+def test_max_adoptions_bounds_a_single_invocation():
+    source = b"def f(x):\n    return x + 1\n\nprint(f(3))\nprint(f(5))\n"
+    client = FakeLLMClient(responses=["```\n(3 + 1)\n```", "```\n(5 + 1)\n```"])
+    result, _ = run_pump(
+        inline_pump(client, max_adoptions=1), source, lambda x: b"print" in x
+    )
+    assert result == b"def f(x):\n    return x + 1\n\nprint((3 + 1))\nprint(f(5))\n"
+
+
+def test_max_completions_bounds_model_calls():
+    source = b"def f(x):\n    return x + 1\n\nprint(f(3))\nprint(f(5))\n"
+    client = FakeLLMClient(responses=["nope", "nope"])
+    result, _ = run_pump(
+        inline_pump(client, max_completions=1), source, lambda x: b"print" in x
+    )
+    assert result == source
+    assert len(client.prompts) == 1
+
+
+class DisabledClient(RecordingClient):
+    def is_disabled(self) -> bool:
+        return True
+
+
+def test_disabled_client_is_never_asked():
+    client = DisabledClient(responses=["```\n(3 + 1)\n```"])
+    result, _ = run_pump(inline_pump(client), PY_SOURCE, lambda x: b"print" in x)
+    assert result == PY_SOURCE
+    assert "complete" not in client.events
+
+
+def test_waits_for_readiness_before_completing():
+    client = RecordingClient(responses=["```\n(3 + 1)\n```"])
+    run_pump(inline_pump(client), PY_SOURCE, lambda x: b"print" in x)
+    assert client.events.index("wait_until_ready") < client.events.index("complete")
+
+
+def test_no_model_interaction_without_targets():
+    client = RecordingClient(responses=["```\n(3 + 1)\n```"])
+    result, _ = run_pump(inline_pump(client), b"hello world\n", lambda x: True)
+    assert result == b"hello world\n"
+    assert client.events == []
+
+
+_REWRITE_BLOCK = re.compile(r"The code to rewrite is:\n\n```\n(.*?)\n```", re.DOTALL)
+
+
+@define
+class InlineOnlyClient(FakeLLMClient):
+    """Inlines `name(number)` calls to an add-one function; nothing else.
+
+    A scripted stand-in for the model: whatever the function and its
+    argument have been renamed to by other passes, a call shaped like
+    `name(number)` is answered with `(number+1)`.
+    """
+
+    async def complete(
+        self, prompt: str, *, max_tokens: int, seed: int, temperature: float
+    ) -> str:
+        await super().complete(
+            prompt, max_tokens=max_tokens, seed=seed, temperature=temperature
+        )
+        block = _REWRITE_BLOCK.search(prompt)
+        if "mechanical refactoring" in prompt and block is not None:
+            call = re.fullmatch(r"\w+\((\d+)\)", block.group(1))
+            if call is not None:
+                return f"```\n({call.group(1)}+1)\n```"
+        return ""
+
+
+@pytest.mark.parametrize("parallelism", [1, 2])
+def test_inlining_unlocks_deleting_the_definition(parallelism):
+    # A semantic oracle: the program must still print 4. The definition
+    # cannot be deleted while the call needs it, and no ordinary pass
+    # rewrites the call into its inlined form; only the combination
+    # reaches a result with no function definition left.
+    def is_interesting(x: bytes) -> bool:
+        out = io.StringIO()
+        try:
+            # Compiling mangled candidates raises SyntaxWarnings (e.g.
+            # "'int' object is not callable"); they are the oracle
+            # rejecting a candidate, not a problem to report.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                code = compile(x.decode("utf-8"), "<candidate>", "exec")
+            with contextlib.redirect_stdout(out):
+                exec(code, {})
+        except Exception:
+            return False
+        return out.getvalue() == "4\n"
+
+    async def acondition(x: bytes) -> bool:
+        await trio.lowlevel.checkpoint()
+        return is_interesting(x)
+
+    async def calc_result() -> bytes:
+        problem: BasicReductionProblem[bytes] = BasicReductionProblem(
+            initial=PY_SOURCE,
+            is_interesting=acondition,
+            work=WorkContext(parallelism=parallelism),
+        )
+        reducer = ShrinkRay(
+            target=problem,
+            llm_client=InlineOnlyClient(),
+            treesitter_language="python",
+            python_reducer=False,
+        )
+        await reducer.run()
+        return problem.current_test_case
+
+    result = trio.run(calc_result)
+    assert is_interesting(result)
+    assert b"def" not in result
+    assert len(result) <= len(b"print((3 + 1))\n")
+
+
+# === Reducer wiring ===
+
+
+def make_shrinkray(**kwargs) -> ShrinkRay:
+    async def is_interesting(x: bytes) -> bool:
+        await trio.lowlevel.checkpoint()
+        return b"boom" in x
+
+    problem: BasicReductionProblem[bytes] = BasicReductionProblem(
+        initial=b"say boom\n",
+        is_interesting=is_interesting,
+        work=WorkContext(parallelism=1),
+    )
+    return ShrinkRay(target=problem, **kwargs)
+
+
+def pump_names(reducer: ShrinkRay) -> list[str]:
+    return [p.__name__ for p in reducer.pumps]
+
+
+def test_llm_transform_pumps_are_named_for_their_language():
+    pumps = llm_transform_pumps(FakeLLMClient(), LLMConfig(), "python")
+    assert [p.__name__ for p in pumps] == ["llm_inline_calls(python)"]
+
+
+def test_reducer_builds_llm_pumps_when_fully_configured():
+    reducer = make_shrinkray(llm_client=FakeLLMClient(), treesitter_language="python")
+    assert pump_names(reducer) == ["llm_inline_calls(python)"]
+
+
+def test_reducer_keeps_cpp_pumps_ahead_of_llm_pumps():
+    reducer = make_shrinkray(
+        llm_client=FakeLLMClient(),
+        treesitter_language="cpp",
+        enable_cpp_passes=True,
+    )
+    assert pump_names(reducer) == [p.__name__ for p in CPP_PUMPS] + [
+        "llm_inline_calls(cpp)"
+    ]
+
+
+def test_no_llm_pumps_without_a_client():
+    reducer = make_shrinkray(treesitter_language="python")
+    assert pump_names(reducer) == []
+
+
+def test_no_llm_pumps_without_a_grammar():
+    reducer = make_shrinkray(llm_client=FakeLLMClient())
+    assert pump_names(reducer) == []

--- a/tests/test_llm_transforms.py
+++ b/tests/test_llm_transforms.py
@@ -524,6 +524,19 @@ def test_unrolls_a_loop_end_to_end():
     assert result == b"print(3)\n"
 
 
+def test_salvages_a_replacement_that_echoes_the_context():
+    # Small models often repeat the reference context (e.g. a function
+    # signature) ahead of the actual replacement; the prefixed variant
+    # must be tried too.
+    source = b"def f(x):\n    y = x + 1\n    return y * 2\nprint(f)\n"
+    client = FakeLLMClient(responses=["```\ndef f(x):\n    pass\n```"])
+    pump = llm_transform_pump(
+        client, LLMConfig(), "python", "llm_stub_bodies(python)", stub_body_targets
+    )
+    result, _ = run_pump(pump, source, lambda x: b"print" in x)
+    assert result == b"def f(x):\n    pass\nprint(f)\n"
+
+
 def test_stubs_a_body_end_to_end():
     source = b"def f(x):\n    y = x + 1\n    return y * 2\nprint(f)\n"
     client = FakeLLMClient(responses=["```\npass\n```"])

--- a/tests/test_llm_transforms.py
+++ b/tests/test_llm_transforms.py
@@ -222,12 +222,33 @@ def test_a_model_echoing_the_call_is_not_retested():
     assert calls == [PY_SOURCE]
 
 
-def test_identical_calls_share_one_completion():
+def test_identical_calls_are_inlined_from_one_completion():
+    # Both calls produce the same prompt; after the first adoption the
+    # second call's splice is satisfied from the cached response.
     source = b"def f(x):\n    return x + 1\n\nprint(f(3))\nprint(f(3))\n"
-    client = FakeLLMClient(responses=["no code block here"])
+    client = FakeLLMClient(responses=["```\n(3 + 1)\n```"])
     result, _ = run_pump(inline_pump(client), source, lambda x: b"print" in x)
-    assert result == source
+    assert result == b"def f(x):\n    return x + 1\n\nprint((3 + 1))\nprint((3 + 1))\n"
     assert len(client.prompts) == 1
+
+
+def test_retries_a_fruitless_prompt_with_a_fresh_seed():
+    client = FakeLLMClient(responses=["no code block here", "```\n(3 + 1)\n```"])
+    result, _ = run_pump(inline_pump(client), PY_SOURCE, lambda x: b"print" in x)
+    assert result == b"def f(x):\n    return x + 1\n\nprint((3 + 1))\n"
+    assert len(client.prompts) == 2
+    assert client.prompts[0] == client.prompts[1]
+    assert client.seeds[0] != client.seeds[1]
+
+
+def test_retries_per_prompt_are_bounded():
+    client = FakeLLMClient()  # always answers with no code block
+    result, _ = run_pump(
+        inline_pump(client, max_prompt_attempts=3), PY_SOURCE, lambda x: b"print" in x
+    )
+    assert result == PY_SOURCE
+    assert len(client.prompts) == 3
+    assert len(set(client.prompts)) == 1
 
 
 def test_rederives_targets_after_each_adoption():


### PR DESCRIPTION
<details>
<summary>AI-generated description</summary>

This teaches the LLM mode a trick that was previously C/C++-only: transformations that temporarily grow the test case to unlock bigger deletions, in any language with a tree-sitter grammar. The grammar finds the site — a call to a function defined in the file, a use of a once-bound name (variable, typedef, macro), a function body, a loop, a constant expression — and the model rewrites just that span: inlining the call or definition, stubbing the body, unrolling the loop's first iteration, or folding the constant. The rest of the file stays untouched byte-for-byte, so a bad rewrite just fails the interestingness test. The canonical win: once every call to a function is inlined, the definition itself becomes deletable.

Also included: a real-model experiment harness (`evaluation/llm_inline_experiment.py`) comparing classical passes, whole-file rewriting, and the pumps on small semantic-oracle problems across Python/JS/Ruby/Go/C, plus fixes from review — augmented assignments (`x += 1`) are no longer treated as inlinable definitions, fruitless pump rounds no longer reparse the file, and the fake LLM clients moved to `tests/helpers.py` for reuse.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)